### PR TITLE
fix(unplugin-service-worker): handle undefined Vite defines

### DIFF
--- a/e2e/vitestSetup.ts
+++ b/e2e/vitestSetup.ts
@@ -10,10 +10,9 @@
  */
 
 import { chromium } from '@playwright/test'
-import { execSync } from 'node:child_process'
-import { dirname, resolve } from 'node:path'
+import { dirname } from 'node:path'
 import { afterAll, beforeAll, inject } from 'vite-plus/test'
-import { createServer, preview } from 'vite'
+import { build, createServer, preview } from 'vite'
 
 import type { Browser, Page } from '@playwright/test'
 import type { PreviewServer, ViteDevServer } from 'vite'
@@ -58,9 +57,9 @@ async function startServer(hostDir: string): Promise<{
 
   if (isBuild) {
     debug('Building host...', hostDir)
-    execSync('npx vite build --minify false', {
-      cwd: hostDir,
-      stdio: E2E_DEBUG ? 'inherit' : 'pipe'
+    await build({
+      root: hostDir,
+      build: { minify: false }
     })
     debug('Build complete')
 

--- a/packages/unplugin-service-worker/src/core/environment-hooks.test.ts
+++ b/packages/unplugin-service-worker/src/core/environment-hooks.test.ts
@@ -1,7 +1,61 @@
 import { describe, expect, it, vi } from 'vite-plus/test'
-import { injectEnvironmentToHooks } from './environment-hooks.ts'
+import { injectEnvironmentToHooks, resolvePluginsForEnvironment } from './environment-hooks.ts'
 
 import type { Plugin } from 'rolldown'
+
+describe('resolvePluginsForEnvironment', () => {
+  const fakeEnvironment = { name: 'client', config: { isBundled: true } }
+
+  it('should keep plugins without applyToEnvironment', async () => {
+    const plugin: Plugin = { name: 'test-plugin' }
+
+    await expect(resolvePluginsForEnvironment(fakeEnvironment, [plugin])).resolves.toEqual([plugin])
+  })
+
+  it('should keep the original plugin when applyToEnvironment returns true', async () => {
+    const applyToEnvironment = vi.fn<(environment: unknown) => boolean>().mockReturnValue(true)
+    const plugin = { name: 'test-plugin', applyToEnvironment } as unknown as Plugin
+
+    await expect(resolvePluginsForEnvironment(fakeEnvironment, [plugin])).resolves.toEqual([plugin])
+    expect(applyToEnvironment).toHaveBeenCalledWith(fakeEnvironment)
+  })
+
+  it('should omit the plugin when applyToEnvironment returns false', async () => {
+    const plugin = {
+      name: 'test-plugin',
+      applyToEnvironment: () => false
+    } as unknown as Plugin
+
+    await expect(resolvePluginsForEnvironment(fakeEnvironment, [plugin])).resolves.toEqual([])
+  })
+
+  it('should use a replacement plugin returned by applyToEnvironment', async () => {
+    const replacement: Plugin = { name: 'replacement-plugin', options: () => undefined }
+    const plugin = {
+      name: 'test-plugin',
+      applyToEnvironment: () => replacement
+    } as unknown as Plugin
+
+    await expect(resolvePluginsForEnvironment(fakeEnvironment, [plugin])).resolves.toEqual([
+      replacement
+    ])
+  })
+
+  it('should flatten asynchronous nested plugin options and remove falsy entries', async () => {
+    const replacementA: Plugin = { name: 'replacement-a' }
+    const replacementB: Plugin = { name: 'replacement-b' }
+    const plugin = {
+      name: 'test-plugin',
+      applyToEnvironment: () =>
+        Promise.resolve([replacementA, Promise.resolve([false, replacementB])])
+    } as unknown as Plugin
+
+    await expect(resolvePluginsForEnvironment(fakeEnvironment, [plugin])).resolves.toEqual([
+      replacementA,
+      replacementB
+    ])
+  })
+})
 
 describe('injectEnvironmentToHooks', () => {
   const fakeEnvironment = { name: 'client', config: { consumer: 'client' } }

--- a/packages/unplugin-service-worker/src/core/environment-hooks.ts
+++ b/packages/unplugin-service-worker/src/core/environment-hooks.ts
@@ -12,12 +12,17 @@
  */
 
 import type { Plugin } from 'rolldown'
+import type { PluginOption } from 'vite'
 
 /**
  * Vite Environment interface (minimal subset needed for hook injection).
  * Using `unknown` to avoid depending on vite types directly.
  */
 type Environment = unknown
+
+type EnvironmentAwarePlugin = Plugin & {
+  applyToEnvironment?: (environment: Environment) => boolean | Promise<boolean> | PluginOption
+}
 
 /**
  * Rolldown plugin hooks that need environment injection.
@@ -169,6 +174,48 @@ function wrapEnvironmentHook(environment: Environment, plugin: Plugin, hookName:
   }
 
   return wrapHook(hook as ObjectHook<typeof handler>, handler)
+}
+
+async function flattenPluginOption(pluginOption: PluginOption): Promise<Plugin[]> {
+  const resolved = await pluginOption
+  if (!resolved) {
+    return []
+  }
+  if (Array.isArray(resolved)) {
+    const nestedPlugins = await Promise.all(resolved.map(flattenPluginOption))
+    return nestedPlugins.flat()
+  }
+  return [resolved as Plugin]
+}
+
+/**
+ * Resolve Vite's per-environment plugin hooks for a standalone environment.
+ *
+ * Mirrors Vite's `resolveEnvironmentPlugins` behavior while operating on the
+ * filtered plugin list used by the Service Worker bundler.
+ */
+export async function resolvePluginsForEnvironment(
+  environment: Environment,
+  plugins: Plugin[]
+): Promise<Plugin[]> {
+  const environmentPlugins: Plugin[] = []
+
+  for (const plugin of plugins) {
+    const environmentPlugin = plugin as EnvironmentAwarePlugin
+    if (environmentPlugin.applyToEnvironment) {
+      const applied = await environmentPlugin.applyToEnvironment(environment)
+      if (!applied) {
+        continue
+      }
+      if (applied !== true) {
+        environmentPlugins.push(...(await flattenPluginOption(applied)))
+        continue
+      }
+    }
+    environmentPlugins.push(plugin)
+  }
+
+  return environmentPlugins
 }
 
 /**

--- a/packages/unplugin-service-worker/src/core/plugin-utils.test.ts
+++ b/packages/unplugin-service-worker/src/core/plugin-utils.test.ts
@@ -1,7 +1,37 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { filterServiceWorkerPlugins, resolveServiceWorkerPlugins } from '../index.ts'
+import {
+  filterServiceWorkerPlugins,
+  resolveServiceWorkerPlugins,
+  sanitizeDefine
+} from '../index.ts'
 
 import type { Plugin } from 'rolldown'
+
+describe('sanitizeDefine', () => {
+  it('should return undefined for undefined input', () => {
+    expect(sanitizeDefine(undefined)).toBeUndefined()
+  })
+
+  it('should convert every supported define value to a string', () => {
+    expect(
+      sanitizeDefine({
+        raw: 'false',
+        number: 123,
+        boolean: true,
+        undefined,
+        null: null,
+        object: { nested: 'value' }
+      })
+    ).toEqual({
+      raw: 'false',
+      number: '123',
+      boolean: 'true',
+      undefined: 'undefined',
+      null: 'null',
+      object: '{"nested":"value"}'
+    })
+  })
+})
 
 describe('filterServiceWorkerPlugins', () => {
   it('should return undefined for undefined input', () => {

--- a/packages/unplugin-service-worker/src/index.ts
+++ b/packages/unplugin-service-worker/src/index.ts
@@ -16,7 +16,7 @@ import {
   SW_FILE_ID,
   SW_QUERY
 } from './core/constants.ts'
-import { injectEnvironmentToHooks } from './core/environment-hooks.ts'
+import { injectEnvironmentToHooks, resolvePluginsForEnvironment } from './core/environment-hooks.ts'
 import { hash } from './core/hash.ts'
 import { resolveOptions } from './core/options.ts'
 import { detectAndResolveServiceWorkers, needsTransform } from './transform/utils.ts'
@@ -232,7 +232,7 @@ function sanitizeDefine(
   return Object.fromEntries(
     Object.entries(define).map(([key, value]) => [
       key,
-      typeof value === 'string' ? value : JSON.stringify(value)
+      value === undefined ? 'undefined' : typeof value === 'string' ? value : JSON.stringify(value)
     ])
   )
 }
@@ -1038,14 +1038,18 @@ function createViteConfigResolved(ctx: PluginContext) {
 
     let adaptedPlugins: import('rolldown').Plugin[] | undefined
     if (workerPlugins && workerPlugins.length > 0) {
+      let swEnvironment: import('vite').BuildEnvironment | undefined
       try {
         const { BuildEnvironment } = await import('vite')
-        const swEnvironment = new BuildEnvironment('client', viteConfig)
+        swEnvironment = new BuildEnvironment('client', viteConfig)
         await swEnvironment.init()
-        adaptedPlugins = workerPlugins.map(p => injectEnvironmentToHooks(swEnvironment, p))
       } catch {
         // If BuildEnvironment is not available (older Vite), fall back to no plugins
-        adaptedPlugins = undefined
+      }
+
+      if (swEnvironment) {
+        const environmentPlugins = await resolvePluginsForEnvironment(swEnvironment, workerPlugins)
+        adaptedPlugins = environmentPlugins.map(p => injectEnvironmentToHooks(swEnvironment, p))
       }
     }
 
@@ -2022,4 +2026,9 @@ export { type Options } from './core/options.ts'
 /**
  * @internal Exported for testing purposes only.
  */
-export { createViteQueryPlugin, filterServiceWorkerPlugins, resolveServiceWorkerPlugins }
+export {
+  createViteQueryPlugin,
+  filterServiceWorkerPlugins,
+  resolveServiceWorkerPlugins,
+  sanitizeDefine
+}


### PR DESCRIPTION
## Summary

- serialize `undefined` Vite define values as the JavaScript expression `undefined`
- resolve Vite `applyToEnvironment` plugin results before adapting hooks for the Service Worker Rolldown build
- use the workspace Vite `build()` API in build-mode E2E setup instead of invoking `npx vite`
- add regression coverage for define sanitization and environment-specific plugin resolution

## Root cause

`JSON.stringify(undefined)` returned JavaScript `undefined`, which violated Rolldown's `Record<string, string>` define contract. Vite 8.1 also exposes the bundled `vite:define` plugin through `applyToEnvironment`, but the Service Worker adapter forwarded the unresolved plugin. The E2E setup additionally allowed `npx` to select a Vite version outside the workspace dependency graph.

## Validation

- `vp run --no-cache test:e2e:build` (6 files passed, 28 tests passed, 6 skipped)
- `vp run --no-cache test:e2e` (6 files passed, 28 tests passed, 6 skipped)
- `vp run test:unit:unplugin` (147 tests passed)
- `vp run --no-cache test:integration:unplugin` (63 tests passed, 1 skipped)
- `vp run --no-cache typecheck`
- `vp run --no-cache lint`
- `vp run --filter @vrowzer/unplugin-service-worker build`

Closes #2
