### PR TITLE
fix(release): mark GitHub prereleases correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,5 +171,12 @@ jobs:
           if gh release view "$TAG" > /dev/null 2>&1; then
             echo "Release $TAG already exists; skipping creation"
           else
-            gh release create "$TAG" --verify-tag --generate-notes
+            is_prerelease=$(node --input-type=module -e \
+              "import { isPrereleaseTag } from './scripts/lib/release-utils.mjs'; process.stdout.write(String(isPrereleaseTag(process.argv[1])))" \
+              "$TAG")
+            release_args=("$TAG" --verify-tag --generate-notes)
+            if [[ "$is_prerelease" == "true" ]]; then
+              release_args+=(--prerelease)
+            fi
+            gh release create "${release_args[@]}"
           fi

--- a/scripts/lib/release-utils.mjs
+++ b/scripts/lib/release-utils.mjs
@@ -27,6 +27,10 @@ export function parseReleaseTag(tag) {
   return version
 }
 
+export function isPrereleaseTag(tag) {
+  return semver.prerelease(parseReleaseTag(tag)) !== null
+}
+
 export function getBumppReleaseTag(operation) {
   const version = operation?.state?.newVersion
   if (typeof version !== 'string') {

--- a/scripts/release-utils.test.ts
+++ b/scripts/release-utils.test.ts
@@ -3,6 +3,7 @@ import {
   getBumppReleaseTag,
   getDistTag,
   getPackageNameFromSpecifier,
+  isPrereleaseTag,
   parseReleaseTag
 } from './lib/release-utils.mjs'
 
@@ -11,6 +12,14 @@ describe('release utilities', () => {
     expect(parseReleaseTag('v1.2.3-beta.1')).toBe('1.2.3-beta.1')
     expect(() => parseReleaseTag('1.2.3')).toThrow('v<semver>')
     expect(() => parseReleaseTag('v01.2.3')).toThrow('canonical')
+  })
+
+  test.each([
+    ['v1.2.3', false],
+    ['v1.2.3-beta.0', true],
+    ['v1.2.3-rc.1', true]
+  ])('identifies whether %s is a prerelease tag', (tag, expected) => {
+    expect(isPrereleaseTag(tag)).toBe(expected)
   })
 
   test('derives the future tag from the version available during the bumpp execute hook', () => {


### PR DESCRIPTION
## Summary

- detect prerelease tags with the existing strict SemVer parser
- pass `--prerelease` when creating GitHub Releases for beta and RC tags
- cover stable, beta, and RC tags with release utility tests

## Root cause

The release workflow always invoked `gh release create` without `--prerelease`, so `v0.1.0-beta.0` was created as a normal GitHub Release even though npm correctly published it under the `beta` dist-tag.

The existing `v0.1.0-beta.0` release metadata has been corrected separately with `gh release edit --prerelease`.

## Validation

- `vp test run --project release:unit` (44 passed)
- `actionlint .github/workflows/release.yml`
- stable and beta tag command checks
- `vp check` (0 errors; existing warnings only)
- `vp test` (291 files passed, 6 skipped; 2233 tests passed, 16 skipped)