### PR TITLE
fix(vrowzer): synchronize custom preview base paths

### DIFF
--- a/packages/unplugin-service-worker/src/core/entry-url.ts
+++ b/packages/unplugin-service-worker/src/core/entry-url.ts
@@ -1,0 +1,115 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { realpathSync } from 'node:fs'
+import MagicString from 'magic-string'
+import path from 'node:path'
+import { SW_ASSET_PREFIX, SW_ASSET_SUFFIX } from './constants.ts'
+import { hash } from './hash.ts'
+import { injectDevQuery } from '../transform/dev.ts'
+
+function safeRealpath(filePath: string): string {
+  try {
+    return path.normalize(realpathSync(filePath))
+  } catch {
+    return path.normalize(filePath)
+  }
+}
+
+export function stripViteBase(pathname: string, base: string): string {
+  const basePath = new URL(base, 'http://localhost').pathname
+  if (basePath === '/') {
+    return pathname
+  }
+
+  const normalizedBase = basePath.endsWith('/') ? basePath : `${basePath}/`
+  if (!pathname.startsWith(normalizedBase)) {
+    return pathname
+  }
+
+  return `/${pathname.slice(normalizedBase.length)}`
+}
+
+/**
+ * Rewrite `new URL('./entry-path', import.meta.url)` references to an explicit
+ * Service Worker entry for the active bundler mode.
+ */
+export function rewriteEntryUrls(
+  code: string,
+  id: string,
+  entryPath: string,
+  root: string,
+  mode: 'placeholder' | 'rollup' | 'dev',
+  emitFile?: (file: { type: 'chunk'; id: string; name: string }) => string,
+  rollupReferenceIds?: Map<string, string>,
+  isTest = false
+): { code: string; map: ReturnType<MagicString['generateMap']> } | null {
+  const urlPatternRE =
+    /new\s+URL\s*\(\s*(['"`])([^'"`]+)\1\s*,\s*(?:['"`]\s*\+\s*)?import\.meta\.url\s*\)/g
+  let urlMatch: RegExpExecArray | null
+  const s = new MagicString(code)
+  let hasReplacement = false
+
+  while ((urlMatch = urlPatternRE.exec(code))) {
+    const urlPath = urlMatch[2]
+    if (!urlPath) {
+      continue
+    }
+
+    const resolvedPath = urlPath.startsWith('.')
+      ? path.resolve(path.dirname(id), urlPath)
+      : urlPath.startsWith('/')
+        ? path.resolve(root, urlPath)
+        : null
+
+    // Resolve workspace symlinks before comparing a library URL with the configured entry.
+    if (resolvedPath && safeRealpath(resolvedPath) === safeRealpath(entryPath)) {
+      if (mode === 'rollup') {
+        if (!emitFile || !rollupReferenceIds) {
+          throw new TypeError('Rollup entry URL rewriting requires emitFile and reference IDs')
+        }
+        let refId = rollupReferenceIds.get(entryPath)
+        if (!refId) {
+          refId = emitFile({
+            type: 'chunk',
+            id: entryPath,
+            name: path.basename(entryPath, path.extname(entryPath))
+          })
+          rollupReferenceIds.set(entryPath, refId)
+        }
+        s.update(
+          urlMatch.index,
+          urlMatch.index + urlMatch[0].length,
+          `new URL(import.meta.ROLLUP_FILE_URL_${refId})`
+        )
+      } else if (mode === 'placeholder') {
+        const placeholder = `${SW_ASSET_PREFIX}${hash(entryPath)}${SW_ASSET_SUFFIX}`
+        s.update(
+          urlMatch.index,
+          urlMatch.index + urlMatch[0].length,
+          `new URL(/* @vite-ignore */ ${JSON.stringify(placeholder)}, '' + import.meta.url)`
+        )
+      } else {
+        const devUrl = injectDevQuery(urlPath)
+        const baseUrl = isTest ? 'self.location.href' : "'' + import.meta.url"
+        s.update(
+          urlMatch.index,
+          urlMatch.index + urlMatch[0].length,
+          `new URL(/* @vite-ignore */ ${JSON.stringify(devUrl)}, ${baseUrl})`
+        )
+      }
+      hasReplacement = true
+    }
+  }
+
+  if (!hasReplacement) {
+    return null
+  }
+
+  return {
+    code: s.toString(),
+    map: s.generateMap({ source: id, file: `${id}.map`, includeContent: true })
+  }
+}

--- a/packages/unplugin-service-worker/src/core/plugin-utils.test.ts
+++ b/packages/unplugin-service-worker/src/core/plugin-utils.test.ts
@@ -4,8 +4,87 @@ import {
   resolveServiceWorkerPlugins,
   sanitizeDefine
 } from '../index.ts'
+import { rewriteEntryUrls, stripViteBase } from './entry-url.ts'
 
 import type { Plugin } from 'rolldown'
+
+describe('rewriteEntryUrls', () => {
+  const id = '/project/node_modules/vrowzer/dist/index.js'
+  const entry = '/project/node_modules/vrowzer/dist/service-worker.ts'
+  const code = `const scriptURL = new URL('./service-worker.ts', import.meta.url)`
+
+  it('should route an explicit entry through the Service Worker bundler in dev', () => {
+    const result = rewriteEntryUrls(code, id, entry, '/project', 'dev')
+
+    expect(result?.code).toContain('./service-worker.ts?sw=service_worker_file')
+    expect(result?.code).toContain("'' + import.meta.url")
+  })
+
+  it('should preserve placeholder rewriting in build mode', () => {
+    const result = rewriteEntryUrls(code, id, entry, '/project', 'placeholder')
+
+    expect(result?.code).toMatch(/__SW_ASSET__[a-z\d]+__/)
+  })
+
+  it('should preserve Rollup chunk emission', () => {
+    const emitted: Array<{ type: 'chunk'; id: string; name: string }> = []
+    const referenceIds = new Map<string, string>()
+    const result = rewriteEntryUrls(
+      code,
+      id,
+      entry,
+      '/project',
+      'rollup',
+      file => {
+        emitted.push(file)
+        return 'service-worker-reference'
+      },
+      referenceIds
+    )
+
+    expect(result?.code).toContain('import.meta.ROLLUP_FILE_URL_service-worker-reference')
+    expect(emitted).toEqual([{ type: 'chunk', id: entry, name: 'service-worker' }])
+    expect(referenceIds.get(entry)).toBe('service-worker-reference')
+  })
+
+  it('should use the page location for an explicit entry in browser tests', () => {
+    const result = rewriteEntryUrls(code, id, entry, '/project', 'dev', undefined, undefined, true)
+
+    expect(result?.code).toContain('self.location.href')
+  })
+
+  it('should ignore a different Service Worker entry', () => {
+    expect(
+      rewriteEntryUrls(
+        code,
+        id,
+        '/project/node_modules/vrowzer/dist/other-worker.ts',
+        '/project',
+        'dev'
+      )
+    ).toBeNull()
+  })
+})
+
+describe('stripViteBase', () => {
+  it('should remove a nested Vite base from a request pathname', () => {
+    expect(stripViteBase('/app/@fs/project/service-worker.ts', '/app/')).toBe(
+      '/@fs/project/service-worker.ts'
+    )
+  })
+
+  it('should keep pathnames outside the configured base', () => {
+    expect(stripViteBase('/application/service-worker.ts', '/app/')).toBe(
+      '/application/service-worker.ts'
+    )
+  })
+
+  it('should keep pathnames unchanged for the root base', () => {
+    expect(stripViteBase('/@fs/project/service-worker.ts', '/')).toBe(
+      '/@fs/project/service-worker.ts'
+    )
+  })
+})
 
 describe('sanitizeDefine', () => {
   it('should return undefined for undefined input', () => {

--- a/packages/unplugin-service-worker/src/index.ts
+++ b/packages/unplugin-service-worker/src/index.ts
@@ -3,7 +3,6 @@
  * @license MIT
  */
 
-import { realpathSync } from 'node:fs'
 import MagicString from 'magic-string'
 import path from 'node:path'
 import { createUnplugin } from 'unplugin'
@@ -16,9 +15,11 @@ import {
   SW_FILE_ID,
   SW_QUERY
 } from './core/constants.ts'
+import { rewriteEntryUrls, stripViteBase } from './core/entry-url.ts'
 import { injectEnvironmentToHooks, resolvePluginsForEnvironment } from './core/environment-hooks.ts'
 import { hash } from './core/hash.ts'
 import { resolveOptions } from './core/options.ts'
+import { injectDevQuery } from './transform/dev.ts'
 import { detectAndResolveServiceWorkers, needsTransform } from './transform/utils.ts'
 
 import type { Compiler as RspackCompiler } from '@rspack/core'
@@ -115,102 +116,6 @@ function replaceWithRollupFileUrl(
  */
 function generatePlaceholderHash(filePath: string): string {
   return hash(filePath)
-}
-
-/**
- * Rewrite `new URL('./entry-path', import.meta.url)` references to the entry Service Worker.
- *
- * When `entry` option is specified, library code (e.g. in node_modules) may contain
- * `new URL()` references to the SW file that need to be rewritten.
- * This function scans for those patterns and replaces them with either:
- * - A placeholder (for Vite/Webpack build) that will be resolved in renderChunk
- * - A ROLLUP_FILE_URL reference (for Rollup/Rolldown)
- *
- * @param code - Source code
- * @param id - Source file ID
- * @param entryPath - Resolved absolute path of the entry SW file
- * @param root - Project root directory
- * @param mode - Replacement mode: 'placeholder' or 'rollup'
- * @param emitFile - Rollup emitFile function (required for 'rollup' mode)
- * @param rollupReferenceIds - Map to store rollup reference IDs (required for 'rollup' mode)
- */
-function safeRealpath(p: string): string {
-  try {
-    return path.normalize(realpathSync(p))
-  } catch {
-    return path.normalize(p)
-  }
-}
-
-function rewriteEntryUrls(
-  code: string,
-  id: string,
-  entryPath: string,
-  root: string,
-  mode: 'placeholder' | 'rollup',
-  emitFile?: (file: { type: 'chunk'; id: string; name: string }) => string,
-  rollupReferenceIds?: Map<string, string>
-): { code: string; map: ReturnType<MagicString['generateMap']> } | null {
-  const urlPatternRE =
-    /new\s+URL\s*\(\s*(['"`])([^'"`]+)\1\s*,\s*(?:['"`]\s*\+\s*)?import\.meta\.url\s*\)/g
-  let urlMatch: RegExpExecArray | null
-  const s = new MagicString(code)
-  let hasReplacement = false
-
-  while ((urlMatch = urlPatternRE.exec(code))) {
-    const urlPath = urlMatch[2]
-    if (!urlPath) {
-      continue
-    }
-
-    const resolvedPath = urlPath.startsWith('.')
-      ? path.resolve(path.dirname(id), urlPath)
-      : urlPath.startsWith('/')
-        ? path.resolve(root, urlPath)
-        : null
-
-    // Use realpathSync to resolve symlinks (e.g. pnpm workspace symlinks)
-    // so that paths like `node_modules/vrowzer/dist/sw.ts` (symlink)
-    // and `packages/vrowzer/dist/sw.ts` (actual) are correctly matched.
-    if (resolvedPath && safeRealpath(resolvedPath) === safeRealpath(entryPath)) {
-      if (mode === 'rollup' && emitFile && rollupReferenceIds) {
-        // Rollup/Rolldown: emit chunk and use ROLLUP_FILE_URL
-        let refId = rollupReferenceIds.get(entryPath)
-        if (!refId) {
-          refId = emitFile({
-            type: 'chunk',
-            id: entryPath,
-            name: path.basename(entryPath, path.extname(entryPath))
-          })
-          rollupReferenceIds.set(entryPath, refId)
-        }
-        s.update(
-          urlMatch.index,
-          urlMatch.index + urlMatch[0].length,
-          `new URL(import.meta.ROLLUP_FILE_URL_${refId})`
-        )
-      } else {
-        // Vite/Webpack: use placeholder
-        const hashStr = generatePlaceholderHash(entryPath)
-        const placeholder = `${SW_ASSET_PREFIX}${hashStr}${SW_ASSET_SUFFIX}`
-        s.update(
-          urlMatch.index,
-          urlMatch.index + urlMatch[0].length,
-          `new URL(/* @vite-ignore */ ${JSON.stringify(placeholder)}, '' + import.meta.url)`
-        )
-      }
-      hasReplacement = true
-    }
-  }
-
-  if (!hasReplacement) {
-    return null
-  }
-
-  return {
-    code: s.toString(),
-    map: s.generateMap({ source: id, file: `${id}.map`, includeContent: true })
-  }
 }
 
 /**
@@ -1087,7 +992,7 @@ function createViteConfigureServer(ctx: PluginContext, options: OptionsResolved)
 
       // Remove query parameter to get the actual file path
       urlObj.searchParams.delete(SW_QUERY)
-      const cleanPath = urlObj.pathname
+      const cleanPath = stripViteBase(urlObj.pathname, server.config.base)
 
       // Try to resolve the file path using multiple strategies
       let filePath: string | null = null
@@ -1770,12 +1675,21 @@ export const ServiceWorkerPlugin: UnpluginInstance<Options | undefined, false> =
             handler(code, id) {
               // When entry is specified, rewrite new URL() references to the entry file
               // in ANY file (including node_modules).
-              if (options.entry && ctx.isBuild) {
+              if (options.entry) {
                 const entryPath = path.isAbsolute(options.entry)
                   ? options.entry
                   : path.resolve(ctx.viteConfig?.root || process.cwd(), options.entry)
                 const root = ctx.viteConfig?.root || process.cwd()
-                const result = rewriteEntryUrls(code, id, entryPath, root, 'placeholder')
+                const result = rewriteEntryUrls(
+                  code,
+                  id,
+                  entryPath,
+                  root,
+                  ctx.isBuild ? 'placeholder' : 'dev',
+                  undefined,
+                  undefined,
+                  ctx.isTest
+                )
                 if (result) {
                   return result
                 }
@@ -1819,9 +1733,7 @@ export const ServiceWorkerPlugin: UnpluginInstance<Options | undefined, false> =
 
               // Dev mode: use query parameter
               for (const sw of resolved) {
-                const hasQuery = sw.urlPath.includes('?')
-                const separator = hasQuery ? '&' : '?'
-                const devUrl = `${sw.urlPath}${separator}${SW_QUERY}=${SW_FILE_ID}`
+                const devUrl = injectDevQuery(sw.urlPath)
 
                 // In test environment (Vitest browser mode), use self.location.href directly
                 // because import.meta.url contains file system paths that don't resolve correctly.

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -39,11 +39,34 @@ The auto-generated manifest is available via the `virtual:vrowzer-manifest` virt
 ```ts
 import manifest from 'virtual:vrowzer-manifest'
 
-const vrowzer = Vrowzer({ basePath: '/__preview__/' })
+const vrowzer = Vrowzer()
 await vrowzer.ready({
   files: { ...manifest.files, ...manifest.nodeModules }
 })
 ```
+
+### Preview base path
+
+The plugin's `basePath` is the source of truth for the application, Web Worker, and Service Worker bundles. Configure it once in `vite.config.ts`; application code can call `Vrowzer()` without repeating the value.
+
+For a host application served from a nested Vite base:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  base: '/app/',
+  plugins: [Vrowzer({ basePath: '/app/__preview__/' })]
+})
+```
+
+```ts
+// application code
+import { Vrowzer } from 'vrowzer'
+
+const vrowzer = Vrowzer()
+```
+
+The runtime `Vrowzer({ basePath })` option remains compatible. When it is also specified, its canonical path must match the plugin value; a mismatch throws during `Vrowzer()` creation. The Service Worker registration `serviceWorkerScope` is independent of this preview URL path.
 
 When the host page and preview content are in different directories, use `manifest.sourceDir`:
 
@@ -165,8 +188,8 @@ Vrowzer({
 | `auto`                 | `boolean`                    | `true`                                    | Enable auto manifest generation. Set `false` to use `VrowzerManifest()` manually.         |
 | `manifest`             | `VrowzerManifestOptions`     | `undefined`                               | Auto manifest options (sourceDir, pkgDir, targets). Used when `auto: true`.               |
 | `experimental`         | `VrowzerExperimentalOptions` | `undefined`                               | Experimental features. Currently supports `ide`.                                          |
-| `basePath`             | `string`                     | `'/__preview__/'`                         | Base path for the preview system. The Service Worker intercepts requests under this path. |
-| `serviceWorkerScope`   | `string`                     | `'/'`                                     | The scope for the Service Worker registration.                                            |
+| `basePath`             | `string`                     | `'/__preview__/'`                         | Preview URL pathname shared with the application and Service Worker bundles.              |
+| `serviceWorkerScope`   | `string`                     | `'/'`                                     | Service Worker registration scope, independent of `basePath`.                             |
 | `serviceWorkerVersion` | `string`                     | `'SERVICE_WORKER_VERSION'`                | Version string for Service Worker cache management.                                       |
 | `serviceWorkerEntry`   | `string`                     | Resolved path to `vrowzer/service-worker` | Explicit Service Worker entry file path.                                                  |
 | `resolve`              | `{ alias?: Alias[] }`        | `undefined`                               | Worker-specific resolve settings passed to the internal Vite dev server.                  |

--- a/packages/vite-plugin/src/env.test.ts
+++ b/packages/vite-plugin/src/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vite-plus/test'
-import { envPlugin } from './env.ts'
+import { envPlugin, VROWZER_PREVIEW_BASE_PATH_DEFINE } from './env.ts'
 import { resolveOptions } from './options.ts'
 
 function createPlugin() {
@@ -75,5 +75,41 @@ describe('envPlugin', () => {
     const result = (plugin as any).config({}, { command: 'serve' })
 
     expect(result.define['import.meta.env.DEBUG']).toBeDefined()
+  })
+
+  test('config hook defines the default preview base path', () => {
+    const plugin = createPlugin()
+    const result = (plugin as any).config({}, { command: 'serve' })
+
+    expect(result.define[VROWZER_PREVIEW_BASE_PATH_DEFINE]).toBe(JSON.stringify('/__preview__/'))
+  })
+
+  test('config hook defines a custom preview base path', () => {
+    const plugin = envPlugin(resolveOptions({ basePath: '/app/__preview__/' }))
+    const result = (plugin as any).config({}, { command: 'serve' })
+
+    expect(result.define[VROWZER_PREVIEW_BASE_PATH_DEFINE]).toBe(
+      JSON.stringify('/app/__preview__/')
+    )
+  })
+
+  test('configResolved accepts the injected preview base path', () => {
+    const plugin = createPlugin()
+    const define = {
+      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/')
+    }
+
+    expect(() => (plugin as any).configResolved({ define })).not.toThrow()
+  })
+
+  test('configResolved rejects an overridden preview base path', () => {
+    const plugin = createPlugin()
+    const define = {
+      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/other/')
+    }
+
+    expect(() => (plugin as any).configResolved({ define })).toThrow(
+      `Vrowzer reserved define ${VROWZER_PREVIEW_BASE_PATH_DEFINE}`
+    )
   })
 })

--- a/packages/vite-plugin/src/env.ts
+++ b/packages/vite-plugin/src/env.ts
@@ -15,10 +15,11 @@ import { fileURLToPath } from 'node:url'
 import { createDebug } from 'obug'
 import { resolveAliases } from './alias.ts'
 
-import type { Plugin } from 'vite'
+import type { Plugin, ResolvedConfig } from 'vite'
 import type { ResolvedVrowzerOptions } from './options.ts'
 
 const debug = createDebug('vite-plugin-vrowzer:env')
+export const VROWZER_PREVIEW_BASE_PATH_DEFINE = '__VROWZER_INTERNAL_PREVIEW_BASE_PATH__'
 
 // Resolve picocolors browser version path.
 // picocolors doesn't export the browser file via package.json exports,
@@ -28,7 +29,8 @@ const picocolorsBrowser = resolve(
   'picocolors.browser.js'
 )
 
-export function envPlugin(_options: ResolvedVrowzerOptions): Plugin {
+export function envPlugin(options: ResolvedVrowzerOptions): Plugin {
+  const serializedBasePath = JSON.stringify(options.basePath)
   return {
     name: 'vrowzer:env',
     // Rolldown native inject: inject `process` global for browser/Worker environments.
@@ -47,7 +49,8 @@ export function envPlugin(_options: ResolvedVrowzerOptions): Plugin {
     config(_config, _env) {
       return {
         define: {
-          'import.meta.env.DEBUG': JSON.stringify(process.env.DEBUG || '')
+          'import.meta.env.DEBUG': JSON.stringify(process.env.DEBUG || ''),
+          [VROWZER_PREVIEW_BASE_PATH_DEFINE]: serializedBasePath
         },
         resolve: {
           alias: resolveAliases({
@@ -77,6 +80,14 @@ export function envPlugin(_options: ResolvedVrowzerOptions): Plugin {
             'Cross-Origin-Embedder-Policy': 'credentialless'
           }
         }
+      }
+    },
+    configResolved(config: ResolvedConfig) {
+      const resolvedBasePath = config.define?.[VROWZER_PREVIEW_BASE_PATH_DEFINE]
+      if (resolvedBasePath !== serializedBasePath) {
+        throw new Error(
+          `Vrowzer reserved define ${VROWZER_PREVIEW_BASE_PATH_DEFINE} must be ${serializedBasePath}, received ${JSON.stringify(resolvedBasePath)}`
+        )
       }
     }
   }

--- a/packages/vite-plugin/src/options.test.ts
+++ b/packages/vite-plugin/src/options.test.ts
@@ -23,6 +23,22 @@ describe('resolveOptions', () => {
     expect(resolved.basePath).toBe('/__custom__/')
   })
 
+  test.each([
+    ['/__custom__', '/__custom__/'],
+    ['/__custom__///', '/__custom__/'],
+    ['/app/__preview__', '/app/__preview__/'],
+    ['/app/__preview__/', '/app/__preview__/']
+  ])('normalizes basePath %s to %s', (basePath, expected) => {
+    expect(resolveOptions({ basePath }).basePath).toBe(expected)
+  })
+
+  test.each(['', '/', 'preview/', '//example.com/preview/', '/preview/?mode=dev', '/preview/#x'])(
+    'rejects invalid basePath %j',
+    basePath => {
+      expect(() => resolveOptions({ basePath })).toThrow(TypeError)
+    }
+  )
+
   test('respects custom serviceWorkerScope', () => {
     const resolved = resolveOptions({ serviceWorkerScope: '/app/' })
 

--- a/packages/vite-plugin/src/options.ts
+++ b/packages/vite-plugin/src/options.ts
@@ -11,6 +11,8 @@
 
 import { fileURLToPath } from 'node:url'
 
+const DEFAULT_BASE_PATH = '/__preview__/'
+
 export interface Alias {
   find: string | RegExp
   replacement: string
@@ -90,12 +92,14 @@ export interface VrowzerOptions {
   manifest?: VrowzerManifestOptions
   /**
    * The base path for the preview system location, which is used to serve the preview files via service worker of Vrowzer.
+   * This is the source of truth for both the application and Service Worker bundles.
    *
    * @default '/__preview__/'
    */
   basePath?: string
   /**
    * The scope for the service worker of Vrowzer, which determines the range of URLs that the service worker will control.
+   * This registration scope is independent of the preview `basePath`.
    *
    * @default '/' (the entire origin)
    */
@@ -158,6 +162,27 @@ function resolveDefaultServiceWorkerEntry(): string {
   }
 }
 
+function normalizeBasePath(basePath: string): string {
+  if (
+    basePath.length === 0 ||
+    !basePath.startsWith('/') ||
+    basePath.startsWith('//') ||
+    basePath.includes('?') ||
+    basePath.includes('#')
+  ) {
+    throw new TypeError(
+      `Vrowzer basePath must be a non-root absolute pathname without a query or hash, received ${JSON.stringify(basePath)}`
+    )
+  }
+
+  const pathname = basePath.replace(/\/+$/, '')
+  if (pathname.length === 0) {
+    throw new TypeError('Vrowzer basePath must not be the origin root "/"')
+  }
+
+  return `${pathname}/`
+}
+
 export function resolveOptions(options: VrowzerOptions): ResolvedVrowzerOptions {
   const ide = options.experimental?.ide
   return {
@@ -168,7 +193,7 @@ export function resolveOptions(options: VrowzerOptions): ResolvedVrowzerOptions 
       port: typeof ide === 'object' ? ide.port : undefined,
       devtools: options.experimental?.devtools ?? false
     },
-    basePath: options.basePath ?? '/__preview__/',
+    basePath: normalizeBasePath(options.basePath ?? DEFAULT_BASE_PATH),
     serviceWorkerScope: options.serviceWorkerScope ?? '/',
     serviceWorkerVersion: options.serviceWorkerVersion ?? 'SERVICE_WORKER_VERSION',
     serviceWorkerEntry: options.serviceWorkerEntry ?? resolveDefaultServiceWorkerEntry(),

--- a/packages/vite-plugin/src/server.test.ts
+++ b/packages/vite-plugin/src/server.test.ts
@@ -53,4 +53,35 @@ describe('serverMiddlewarePlugin', () => {
     expect(next).toHaveBeenCalled()
     expect(res.writeHead).not.toHaveBeenCalled()
   })
+
+  test.each(['/__preview__', '/__preview__/', '/__preview__/main.js?import'])(
+    'previewGuardMiddleware returns 503 for bounded preview path %s',
+    requestUrl => {
+      const plugin = serverMiddlewarePlugin(resolveOptions({ basePath: '/__preview__/' }))
+      const req = { url: requestUrl } as any
+      const res = { writeHead: vi.fn(), end: vi.fn() } as any
+      const next = vi.fn()
+      const middlewares = { use: vi.fn() }
+      ;(plugin as any).configureServer({ middlewares })
+
+      middlewares.use.mock.calls[0]![0](req, res, next)
+
+      expect(res.writeHead).toHaveBeenCalledWith(503, expect.any(Object))
+      expect(next).not.toHaveBeenCalled()
+    }
+  )
+
+  test('previewGuardMiddleware passes through a similar path prefix', () => {
+    const plugin = serverMiddlewarePlugin(resolveOptions({ basePath: '/__preview__/' }))
+    const req = { url: '/__preview__-other/' } as any
+    const res = { writeHead: vi.fn(), end: vi.fn() } as any
+    const next = vi.fn()
+    const middlewares = { use: vi.fn() }
+    ;(plugin as any).configureServer({ middlewares })
+
+    middlewares.use.mock.calls[0]![0](req, res, next)
+
+    expect(next).toHaveBeenCalled()
+    expect(res.writeHead).not.toHaveBeenCalled()
+  })
 })

--- a/packages/vite-plugin/src/server.ts
+++ b/packages/vite-plugin/src/server.ts
@@ -24,11 +24,13 @@ const debug = createDebug('vite-plugin-vrowzer:server')
  * preview requests bypass service worker and hit Vite directly.
  * Without this guard, Vite returns the main page HTML, causing recursive display.
  */
-function previewGuardMiddleware(previewBase: string = '/__preview__') {
+function previewGuardMiddleware(previewBase: string) {
+  const previewRoot = previewBase.slice(0, -1)
   return (req: IncomingMessage, res: ServerResponse, next: () => void) => {
     debug('previewGuardMiddleware: previewBase ', previewBase, ' req.url ', req.url)
 
-    if (req.url?.startsWith(previewBase)) {
+    const pathname = req.url ? new URL(req.url, 'http://localhost').pathname : undefined
+    if (pathname === previewRoot || pathname?.startsWith(previewBase)) {
       res.writeHead(503, {
         'Content-Type': 'text/html',
         'Retry-After': '1'
@@ -44,7 +46,7 @@ function previewGuardMiddleware(previewBase: string = '/__preview__') {
 }
 
 export function serverMiddlewarePlugin(options: ResolvedVrowzerOptions): Plugin {
-  const middleware = previewGuardMiddleware(normalizeBasePath(options.basePath))
+  const middleware = previewGuardMiddleware(options.basePath)
   return {
     name: 'vrowzer:server-middleware',
     configureServer(server) {
@@ -53,14 +55,5 @@ export function serverMiddlewarePlugin(options: ResolvedVrowzerOptions): Plugin 
     configurePreviewServer(server) {
       server.middlewares.use(middleware)
     }
-  }
-}
-
-function normalizeBasePath(basePath: string): string {
-  debug('normalizeBasePath: basePath ', basePath)
-  if (basePath.endsWith('/')) {
-    return basePath.slice(0, -1)
-  } else {
-    return basePath
   }
 }

--- a/packages/vrowzer/README.md
+++ b/packages/vrowzer/README.md
@@ -46,7 +46,7 @@ export default defineConfig({
 ```ts
 import { Vrowzer } from 'vrowzer'
 
-const vrowzer = Vrowzer({ basePath: '/__preview__/' })
+const vrowzer = Vrowzer()
 
 // Initialize with files
 const ready = await vrowzer.ready({
@@ -79,13 +79,37 @@ vrowzer.updateFile(
 
 Creates a new Vrowzer instance.
 
+When `@vrowzer/vite-plugin` is used, configure the preview URL with the plugin's `basePath`. The value is shared with the application, Web Worker, and Service Worker, so the runtime option can be omitted:
+
+```ts
+// vite.config.ts
+import { Vrowzer as VrowzerPlugin } from '@vrowzer/vite-plugin'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  base: '/app/',
+  plugins: [VrowzerPlugin({ basePath: '/app/__preview__/' })]
+})
+```
+
+```ts
+// application.ts
+import { Vrowzer } from 'vrowzer'
+
+const vrowzer = Vrowzer()
+```
+
+The runtime `basePath` remains available for compatibility and for usage without the plugin. If both the plugin and runtime values are provided, their canonical paths must match or `Vrowzer()` throws. Without either value, the preview path is `/__preview__/`.
+
+`serviceWorkerScope` controls which pages the browser allows the Service Worker to control. It does not set the preview URL; that is the role of `basePath`.
+
 **Options:**
 
-| Option                 | Type     | Default           | Description                      |
-| ---------------------- | -------- | ----------------- | -------------------------------- |
-| `basePath`             | `string` | `'/__preview__/'` | Base path for the preview system |
-| `serviceWorkerVersion` | `string` | `'vrowzer-v1'`    | SW version for cache management  |
-| `serviceWorkerScope`   | `string` | `'/'`             | SW registration scope            |
+| Option                 | Type     | Default                           | Description                                       |
+| ---------------------- | -------- | --------------------------------- | ------------------------------------------------- |
+| `basePath`             | `string` | Plugin value or `'/__preview__/'` | Preview URL pathname; must match the plugin value  |
+| `serviceWorkerVersion` | `string` | `'vrowzer-v1'`                    | SW version for cache management                   |
+| `serviceWorkerScope`   | `string` | `'/'`                             | SW registration scope, independent of `basePath`  |
 
 ### Instance Methods
 

--- a/packages/vrowzer/docs/default/interfaces/VrowzerOptions.md
+++ b/packages/vrowzer/docs/default/interfaces/VrowzerOptions.md
@@ -12,6 +12,6 @@ export interface VrowzerOptions
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `basePath` _(optional)_ | `string` | Preview base path (default: '/__preview__/') |
-| `serviceWorkerScope` _(optional)_ | `string` | Service Worker scope (default: '/') |
+| `basePath` _(optional)_ | `string` | Preview URL pathname. When `@vrowzer/vite-plugin` is used, its `basePath` is injected and this option can be omitted. If both are provided, their canonical values must match. Without the plugin, this option defaults to `'/__preview__/'`. |
+| `serviceWorkerScope` _(optional)_ | `string` | Service Worker registration scope, independent of `basePath` (default: '/') |
 | `serviceWorkerVersion` _(optional)_ | `string` | Service Worker version for cache management (default: 'vrowzer-v1') |

--- a/packages/vrowzer/docs/index.md
+++ b/packages/vrowzer/docs/index.md
@@ -7,7 +7,7 @@ Vrowzer - Preview with Vite HMR flavor for the browser
 ```ts
 import { Vrowzer } from 'vrowzer'
 
-const vrowzer = Vrowzer({ basePath: '/__preview__/' })
+const vrowzer = Vrowzer()
 
 // Initialize with files
 const ready = await vrowzer.ready({

--- a/packages/vrowzer/integration/custom-base.integration-test.ts
+++ b/packages/vrowzer/integration/custom-base.integration-test.ts
@@ -1,0 +1,122 @@
+import { chromium } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { build, createServer, preview } from 'vite'
+import { expect, test } from 'vite-plus/test'
+
+import type { Browser, BrowserContext, Page } from '@playwright/test'
+import type { PreviewServer, ViteDevServer } from 'vite'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const FIXTURE_DIR = join(__dirname, 'custom-base')
+const HOST_BASE = '/app/'
+const PREVIEW_BASE = '/app/__preview__/'
+const PREVIEW_MODULE = `${PREVIEW_BASE}main.js`
+const PREVIEW_TEXT = 'Custom base preview works'
+
+type TestMode = 'development' | 'build'
+type TestServer = PreviewServer | ViteDevServer
+
+async function startServer(mode: TestMode): Promise<TestServer> {
+  if (mode === 'build') {
+    await build({ root: FIXTURE_DIR, logLevel: 'silent' })
+    return preview({
+      root: FIXTURE_DIR,
+      logLevel: 'silent',
+      preview: { port: 0, strictPort: false }
+    })
+  }
+
+  const server = await createServer({
+    root: FIXTURE_DIR,
+    logLevel: 'silent',
+    server: { port: 0, strictPort: false }
+  })
+  await server.listen()
+  return server
+}
+
+function getServerOrigin(server: TestServer): string {
+  const address = server.httpServer?.address()
+  if (typeof address !== 'object' || !address) {
+    throw new Error('Failed to get custom base integration server address')
+  }
+  return `http://localhost:${address.port}`
+}
+
+async function waitForReady(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const text = document.getElementById('status')?.textContent ?? ''
+      return text === 'Ready' || text.startsWith('Error') || text.startsWith('Failed')
+    },
+    undefined,
+    { timeout: 60_000 }
+  )
+  expect(await page.textContent('#status')).toBe('Ready')
+}
+
+async function expectPreviewContent(page: Page): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const iframe = document.querySelector('#preview-container iframe') as HTMLIFrameElement
+          return iframe?.contentDocument?.body?.innerText ?? ''
+        }),
+      { timeout: 15_000 }
+    )
+    .toContain(PREVIEW_TEXT)
+
+  const response = await page.evaluate(async previewBase => {
+    const result = await fetch(previewBase)
+    return { status: result.status, body: await result.text() }
+  }, PREVIEW_BASE)
+  expect(response.status).toBe(200)
+  expect(response.body).toContain('Custom base preview')
+  expect(response.body).not.toContain('Waiting for Service Worker...')
+
+  const moduleResponse = await page.evaluate(async previewModule => {
+    const result = await fetch(previewModule)
+    return { status: result.status, body: await result.text() }
+  }, PREVIEW_MODULE)
+  expect(moduleResponse.status).toBe(200)
+  expect(moduleResponse.body).toContain(PREVIEW_TEXT)
+}
+
+async function runScenario(mode: TestMode): Promise<void> {
+  let browser: Browser | undefined
+  let context: BrowserContext | undefined
+  let server: TestServer | undefined
+  const logs: string[] = []
+
+  try {
+    server = await startServer(mode)
+    browser = await chromium.launch({ headless: true })
+    context = await browser.newContext()
+    const page = await context.newPage()
+    page.on('console', message => logs.push(`[console:${message.type()}] ${message.text()}`))
+    page.on('pageerror', error => logs.push(`[pageerror] ${error.message}`))
+
+    await page.goto(`${getServerOrigin(server)}${HOST_BASE}`)
+    await waitForReady(page)
+    await expectPreviewContent(page)
+
+    await page.reload()
+    await waitForReady(page)
+    await expectPreviewContent(page)
+
+    expect(logs.join('\n')).not.toMatch(
+      /Service Worker (?:listen\(\) did not complete|registration error)/
+    )
+  } catch (error) {
+    throw new Error(`Custom base ${mode} scenario failed\n${logs.join('\n')}`, { cause: error })
+  } finally {
+    await context?.close()
+    await browser?.close()
+    await server?.close()
+  }
+}
+
+test('supports a custom base in development', () => runScenario('development'), 120_000)
+test('supports a custom base in build', () => runScenario('build'), 120_000)

--- a/packages/vrowzer/integration/custom-base/index.html
+++ b/packages/vrowzer/integration/custom-base/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vrowzer custom base integration</title>
+  </head>
+  <body>
+    <div id="status">Initializing...</div>
+    <div id="preview-container"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/vrowzer/integration/custom-base/main.ts
+++ b/packages/vrowzer/integration/custom-base/main.ts
@@ -1,0 +1,36 @@
+import { Vrowzer } from 'vrowzer'
+
+const status = document.getElementById('status')!
+const container = document.getElementById('preview-container')!
+
+const vrowzer = Vrowzer()
+
+async function init() {
+  try {
+    const ready = await vrowzer.ready({
+      files: {
+        '/index.html': `<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Custom base preview</title></head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>`,
+        '/main.js': `document.querySelector('#app').textContent = 'Custom base preview works'`
+      }
+    })
+
+    if (!ready) {
+      status.textContent = 'Failed to initialize'
+      return
+    }
+
+    vrowzer.mount(container)
+    status.textContent = 'Ready'
+  } catch (error) {
+    status.textContent = `Error: ${error instanceof Error ? error.message : String(error)}`
+  }
+}
+
+void init()

--- a/packages/vrowzer/integration/custom-base/vite.config.ts
+++ b/packages/vrowzer/integration/custom-base/vite.config.ts
@@ -1,0 +1,17 @@
+import { Vrowzer as VrowzerPlugin } from '@vrowzer/vite-plugin'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite-plus'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  base: '/app/',
+  plugins: [
+    VrowzerPlugin({
+      auto: false,
+      basePath: '/app/__preview__/',
+      serviceWorkerEntry: resolve(__dirname, '../../dist/service-worker.ts')
+    })
+  ]
+})

--- a/packages/vrowzer/src/index.ts
+++ b/packages/vrowzer/src/index.ts
@@ -5,7 +5,7 @@
  * ```ts
  * import { Vrowzer } from 'vrowzer'
  *
- * const vrowzer = Vrowzer({ basePath: '/__preview__/' })
+ * const vrowzer = Vrowzer()
  *
  * // Initialize with files
  * const ready = await vrowzer.ready({
@@ -53,6 +53,7 @@ import {
   V_SW_CONNECT_PORT_ACK
 } from '@vrowzer/vite-dev-server/messages'
 import { getServiceWorker, getController, initServiceWorker } from './controller.ts'
+import { resolvePreviewBasePath } from './preview-base.ts'
 
 import type { Emittable } from '@kazupon/jts-utils/event/emitter'
 import type { FileSystemPublisher } from '@vrowzer/fs/watcher'
@@ -62,11 +63,17 @@ import type { SvcWorkerControllerEventMap } from '@vrowzer/service-worker/contro
  * VrowzerOptions defines the configuration options for {@link Vrowzer}.
  */
 export interface VrowzerOptions {
-  /** Preview base path (default: '/__preview__/') */
+  /**
+   * Preview URL pathname.
+   *
+   * When `@vrowzer/vite-plugin` is used, its `basePath` is injected and this option can be
+   * omitted. If both are provided, their canonical values must match. Without the plugin,
+   * this option defaults to `'/__preview__/'`.
+   */
   basePath?: string
   /** Service Worker version for cache management (default: 'vrowzer-v1') */
   serviceWorkerVersion?: string
-  /** Service Worker scope (default: '/') */
+  /** Service Worker registration scope, independent of `basePath` (default: '/') */
   serviceWorkerScope?: string
 }
 
@@ -141,7 +148,7 @@ interface ResolvedVrowzerOptions {
 
 function resolveVrowzerOptions(options: VrowzerOptions): ResolvedVrowzerOptions {
   return {
-    basePath: options.basePath ?? '/__preview__/',
+    basePath: resolvePreviewBasePath(options.basePath),
     serviceWorkerVersion: options.serviceWorkerVersion ?? 'vrowzer-v1',
     serviceWorkerScope: options.serviceWorkerScope ?? '/'
   }

--- a/packages/vrowzer/src/preview-base.test.ts
+++ b/packages/vrowzer/src/preview-base.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vite-plus/test'
+import {
+  DEFAULT_PREVIEW_BASE_PATH,
+  normalizePreviewBasePath,
+  resolvePreviewBasePath
+} from './preview-base.ts'
+
+describe('normalizePreviewBasePath', () => {
+  test.each([
+    ['/__preview__', '/__preview__/'],
+    ['/__preview__///', '/__preview__/'],
+    ['/app/__preview__', '/app/__preview__/'],
+    ['/app/__preview__/', '/app/__preview__/']
+  ])('normalizes %s to %s', (basePath, expected) => {
+    expect(normalizePreviewBasePath(basePath)).toBe(expected)
+  })
+
+  test.each(['', '/', 'preview/', '//example.com/preview/', '/preview/?mode=dev', '/preview/#x'])(
+    'rejects invalid basePath %j',
+    basePath => {
+      expect(() => normalizePreviewBasePath(basePath)).toThrow(TypeError)
+    }
+  )
+})
+
+describe('resolvePreviewBasePath', () => {
+  test('falls back to the default without runtime or injected values', () => {
+    expect(resolvePreviewBasePath()).toBe(DEFAULT_PREVIEW_BASE_PATH)
+  })
+
+  test('uses the runtime value without an injected value', () => {
+    expect(resolvePreviewBasePath('/runtime', undefined)).toBe('/runtime/')
+  })
+
+  test('uses the injected value without a runtime value', () => {
+    expect(resolvePreviewBasePath(undefined, '/injected')).toBe('/injected/')
+  })
+
+  test('accepts equal canonical runtime and injected values', () => {
+    expect(resolvePreviewBasePath('/app/__preview__', '/app/__preview__/')).toBe(
+      '/app/__preview__/'
+    )
+  })
+
+  test('rejects different runtime and injected values', () => {
+    expect(() => resolvePreviewBasePath('/runtime/', '/injected/')).toThrow(
+      'Configure basePath in vite.config.ts'
+    )
+  })
+})

--- a/packages/vrowzer/src/preview-base.ts
+++ b/packages/vrowzer/src/preview-base.ts
@@ -1,0 +1,53 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+export const DEFAULT_PREVIEW_BASE_PATH = '/__preview__/'
+
+declare const __VROWZER_INTERNAL_PREVIEW_BASE_PATH__: string
+
+function getInjectedPreviewBasePath(): string | undefined {
+  return typeof __VROWZER_INTERNAL_PREVIEW_BASE_PATH__ === 'string'
+    ? __VROWZER_INTERNAL_PREVIEW_BASE_PATH__
+    : undefined
+}
+
+export function normalizePreviewBasePath(basePath: string): string {
+  if (
+    basePath.length === 0 ||
+    !basePath.startsWith('/') ||
+    basePath.startsWith('//') ||
+    basePath.includes('?') ||
+    basePath.includes('#')
+  ) {
+    throw new TypeError(
+      `Vrowzer basePath must be a non-root absolute pathname without a query or hash, received ${JSON.stringify(basePath)}`
+    )
+  }
+
+  const pathname = basePath.replace(/\/+$/, '')
+  if (pathname.length === 0) {
+    throw new TypeError('Vrowzer basePath must not be the origin root "/"')
+  }
+
+  return `${pathname}/`
+}
+
+export function resolvePreviewBasePath(
+  runtimeBasePath?: string,
+  injectedBasePath: string | undefined = getInjectedPreviewBasePath()
+): string {
+  const runtime =
+    runtimeBasePath === undefined ? undefined : normalizePreviewBasePath(runtimeBasePath)
+  const injected =
+    injectedBasePath === undefined ? undefined : normalizePreviewBasePath(injectedBasePath)
+
+  if (runtime !== undefined && injected !== undefined && runtime !== injected) {
+    throw new Error(
+      `Vrowzer basePath ${JSON.stringify(runtime)} does not match @vrowzer/vite-plugin basePath ${JSON.stringify(injected)}. Configure basePath in vite.config.ts.`
+    )
+  }
+
+  return injected ?? runtime ?? DEFAULT_PREVIEW_BASE_PATH
+}

--- a/packages/vrowzer/src/service-worker-core.ts
+++ b/packages/vrowzer/src/service-worker-core.ts
@@ -25,6 +25,7 @@ import client from '@vrowzer/vite-dev-server/dist/client/client.mjs?raw' // oxli
 import env from '@vrowzer/vite-dev-server/dist/client/env.mjs?raw'
 import { createServer } from '@vrowzer/vite-dev-server/service-worker'
 import { V_SW_LISTEN_READY, V_SW_LISTEN_READY_PING } from '@vrowzer/vite-dev-server/messages'
+import { resolvePreviewBasePath } from './preview-base.ts'
 
 import type { FileSystemSyncMessage } from '@vrowzer/fs/watcher'
 import type { CreateServerOptions } from '@vrowzer/vite-dev-server/service-worker'
@@ -44,7 +45,7 @@ export async function initServiceWorker(options?: { plugins?: Plugin[] }) {
   fs.writeFileSync('/public/.gitkeep', '', { encoding: 'utf8' })
 
   const subscriber = createFileSystemSubscriber(fs)
-  const previewBase = '/__preview__/'
+  const previewBase = resolvePreviewBasePath()
   const serverOptions = {
     version: SW_VERSION,
     basePath: previewBase,

--- a/packages/vrowzer/vite.config.ts
+++ b/packages/vrowzer/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
           cpSync(resolve(srcDir, 'web-worker.ts'), resolve(distDir, 'web-worker.ts'))
           cpSync(resolve(srcDir, 'web-worker-core.ts'), resolve(distDir, 'web-worker-core.ts'))
           cpSync(resolve(srcDir, 'service-worker.ts'), resolve(distDir, 'service-worker.ts'))
+          cpSync(resolve(srcDir, 'preview-base.ts'), resolve(distDir, 'preview-base.ts'))
           cpSync(
             resolve(srcDir, 'service-worker-core.ts'),
             resolve(distDir, 'service-worker-core.ts')


### PR DESCRIPTION
## Summary

- canonicalize the preview `basePath` in `@vrowzer/vite-plugin` and inject it into application and Service Worker builds
- use one resolved preview base across the page runtime, Web Worker, and Service Worker, with a clear error for mismatched runtime configuration
- support explicit Service Worker entries under nested Vite bases without exposing new public APIs
- add development and production integration coverage for `/app/__preview__/` and update the related documentation

Closes #10

## Validation

- `vp check` (0 errors; 720 existing warnings)
- `vp run build`
- `vp run test`
- `vp run test:e2e:build`