### PR TITLE
fix(vrowzer): sync service worker scope

### DIFF
--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -68,6 +68,32 @@ const vrowzer = Vrowzer()
 
 The runtime `Vrowzer({ basePath })` option remains compatible. When it is also specified, its canonical path must match the plugin value; a mismatch throws during `Vrowzer()` creation. The Service Worker registration `serviceWorkerScope` is independent of this preview URL path.
 
+### Service Worker scope
+
+The plugin's `serviceWorkerScope` is the source of truth for both Service Worker registration and the `Service-Worker-Allowed` response header. Configure it once in `vite.config.ts`; the runtime option can be omitted:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  base: '/app/',
+  plugins: [
+    Vrowzer({
+      basePath: '/app/__preview__/',
+      serviceWorkerScope: '/app/'
+    })
+  ]
+})
+```
+
+```ts
+// application code
+import { Vrowzer } from 'vrowzer'
+
+const vrowzer = Vrowzer()
+```
+
+The runtime `Vrowzer({ serviceWorkerScope })` option remains available for compatibility and for builds without the plugin. If both values are provided, they must match or `Vrowzer()` throws before registration. Without either value, the scope and response header default to `/`.
+
 When the host page and preview content are in different directories, use `manifest.sourceDir`:
 
 ```ts
@@ -163,7 +189,7 @@ Vrowzer({
   // Default: '/__preview__/'
   basePath: '/__preview__/',
 
-  // Service Worker scope
+  // Service Worker registration scope and allowed response header
   // Default: '/'
   serviceWorkerScope: '/',
 
@@ -189,7 +215,7 @@ Vrowzer({
 | `manifest`             | `VrowzerManifestOptions`     | `undefined`                               | Auto manifest options (sourceDir, pkgDir, targets). Used when `auto: true`.               |
 | `experimental`         | `VrowzerExperimentalOptions` | `undefined`                               | Experimental features. Currently supports `ide`.                                          |
 | `basePath`             | `string`                     | `'/__preview__/'`                         | Preview URL pathname shared with the application and Service Worker bundles.              |
-| `serviceWorkerScope`   | `string`                     | `'/'`                                     | Service Worker registration scope, independent of `basePath`.                             |
+| `serviceWorkerScope`   | `string`                     | `'/'`                                     | Registration scope and `Service-Worker-Allowed` header injected into the runtime.          |
 | `serviceWorkerVersion` | `string`                     | `'SERVICE_WORKER_VERSION'`                | Version string for Service Worker cache management.                                       |
 | `serviceWorkerEntry`   | `string`                     | Resolved path to `vrowzer/service-worker` | Explicit Service Worker entry file path.                                                  |
 | `resolve`              | `{ alias?: Alias[] }`        | `undefined`                               | Worker-specific resolve settings passed to the internal Vite dev server.                  |
@@ -255,7 +281,7 @@ Sets up Vite configuration for the browser-based Vite dev server:
 
 - **`resolve.alias`** — Maps Node.js built-in modules (`node:fs`, `node:path`, `node:events`, etc.) to browser-compatible polyfills
 - **`worker.format`** — Set to `'es'` for ES Module workers
-- **CORS headers** — `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: credentialless`, plus `Service-Worker-Allowed: /`
+- **CORS headers** — `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: credentialless`, plus `Service-Worker-Allowed` matching `serviceWorkerScope` (default `/`)
 
 #### 6. Rolldown WASM Copy (`vrowzer:rolldown`)
 

--- a/packages/vite-plugin/src/env.test.ts
+++ b/packages/vite-plugin/src/env.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from 'vite-plus/test'
-import { envPlugin, VROWZER_PREVIEW_BASE_PATH_DEFINE } from './env.ts'
+import {
+  envPlugin,
+  VROWZER_PREVIEW_BASE_PATH_DEFINE,
+  VROWZER_SERVICE_WORKER_SCOPE_DEFINE
+} from './env.ts'
 import { resolveOptions } from './options.ts'
 
-function createPlugin() {
-  return envPlugin(resolveOptions({}))
+function createPlugin(options: Parameters<typeof resolveOptions>[0] = {}) {
+  return envPlugin(resolveOptions(options))
 }
 
 describe('envPlugin', () => {
@@ -52,6 +56,7 @@ describe('envPlugin', () => {
 
     expect(result.server.headers['Cross-Origin-Opener-Policy']).toBe('same-origin')
     expect(result.server.headers['Cross-Origin-Embedder-Policy']).toBe('credentialless')
+    expect(result.server.headers['Service-Worker-Allowed']).toBe('/')
   })
 
   test('config hook sets CORS headers for preview', () => {
@@ -61,6 +66,14 @@ describe('envPlugin', () => {
     expect(result.preview.headers['Cross-Origin-Opener-Policy']).toBe('same-origin')
     expect(result.preview.headers['Cross-Origin-Embedder-Policy']).toBe('credentialless')
     expect(result.preview.headers['Service-Worker-Allowed']).toBe('/')
+  })
+
+  test('config hook uses a custom service worker scope for server and preview', () => {
+    const plugin = createPlugin({ serviceWorkerScope: '/app/' })
+    const result = (plugin as any).config({}, { command: 'serve' })
+
+    expect(result.server.headers['Service-Worker-Allowed']).toBe('/app/')
+    expect(result.preview.headers['Service-Worker-Allowed']).toBe('/app/')
   })
 
   test('config hook sets worker format to "es"', () => {
@@ -93,10 +106,25 @@ describe('envPlugin', () => {
     )
   })
 
+  test('config hook defines the default service worker scope', () => {
+    const plugin = createPlugin()
+    const result = (plugin as any).config({}, { command: 'serve' })
+
+    expect(result.define[VROWZER_SERVICE_WORKER_SCOPE_DEFINE]).toBe(JSON.stringify('/'))
+  })
+
+  test('config hook defines a custom service worker scope', () => {
+    const plugin = createPlugin({ serviceWorkerScope: '/app/' })
+    const result = (plugin as any).config({}, { command: 'serve' })
+
+    expect(result.define[VROWZER_SERVICE_WORKER_SCOPE_DEFINE]).toBe(JSON.stringify('/app/'))
+  })
+
   test('configResolved accepts the injected preview base path', () => {
     const plugin = createPlugin()
     const define = {
-      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/')
+      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/'),
+      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/')
     }
 
     expect(() => (plugin as any).configResolved({ define })).not.toThrow()
@@ -105,11 +133,35 @@ describe('envPlugin', () => {
   test('configResolved rejects an overridden preview base path', () => {
     const plugin = createPlugin()
     const define = {
-      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/other/')
+      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/other/'),
+      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/')
     }
 
     expect(() => (plugin as any).configResolved({ define })).toThrow(
       `Vrowzer reserved define ${VROWZER_PREVIEW_BASE_PATH_DEFINE}`
+    )
+  })
+
+  test('configResolved rejects an overridden service worker scope', () => {
+    const plugin = createPlugin()
+    const define = {
+      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/'),
+      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/other/')
+    }
+
+    expect(() => (plugin as any).configResolved({ define })).toThrow(
+      `Vrowzer reserved define ${VROWZER_SERVICE_WORKER_SCOPE_DEFINE}`
+    )
+  })
+
+  test('configResolved rejects a missing service worker scope', () => {
+    const plugin = createPlugin()
+    const define = {
+      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/')
+    }
+
+    expect(() => (plugin as any).configResolved({ define })).toThrow(
+      `Vrowzer reserved define ${VROWZER_SERVICE_WORKER_SCOPE_DEFINE}`
     )
   })
 })

--- a/packages/vite-plugin/src/env.ts
+++ b/packages/vite-plugin/src/env.ts
@@ -20,6 +20,7 @@ import type { ResolvedVrowzerOptions } from './options.ts'
 
 const debug = createDebug('vite-plugin-vrowzer:env')
 export const VROWZER_PREVIEW_BASE_PATH_DEFINE = '__VROWZER_INTERNAL_PREVIEW_BASE_PATH__'
+export const VROWZER_SERVICE_WORKER_SCOPE_DEFINE = '__VROWZER_INTERNAL_SERVICE_WORKER_SCOPE__'
 
 // Resolve picocolors browser version path.
 // picocolors doesn't export the browser file via package.json exports,
@@ -31,6 +32,7 @@ const picocolorsBrowser = resolve(
 
 export function envPlugin(options: ResolvedVrowzerOptions): Plugin {
   const serializedBasePath = JSON.stringify(options.basePath)
+  const serializedServiceWorkerScope = JSON.stringify(options.serviceWorkerScope)
   return {
     name: 'vrowzer:env',
     // Rolldown native inject: inject `process` global for browser/Worker environments.
@@ -50,7 +52,8 @@ export function envPlugin(options: ResolvedVrowzerOptions): Plugin {
       return {
         define: {
           'import.meta.env.DEBUG': JSON.stringify(process.env.DEBUG || ''),
-          [VROWZER_PREVIEW_BASE_PATH_DEFINE]: serializedBasePath
+          [VROWZER_PREVIEW_BASE_PATH_DEFINE]: serializedBasePath,
+          [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: serializedServiceWorkerScope
         },
         resolve: {
           alias: resolveAliases({
@@ -68,14 +71,14 @@ export function envPlugin(options: ResolvedVrowzerOptions): Plugin {
         },
         server: {
           headers: {
-            'Service-Worker-Allowed': '/',
+            'Service-Worker-Allowed': options.serviceWorkerScope,
             'Cross-Origin-Opener-Policy': 'same-origin',
             'Cross-Origin-Embedder-Policy': 'credentialless'
           }
         },
         preview: {
           headers: {
-            'Service-Worker-Allowed': '/',
+            'Service-Worker-Allowed': options.serviceWorkerScope,
             'Cross-Origin-Opener-Policy': 'same-origin',
             'Cross-Origin-Embedder-Policy': 'credentialless'
           }
@@ -87,6 +90,13 @@ export function envPlugin(options: ResolvedVrowzerOptions): Plugin {
       if (resolvedBasePath !== serializedBasePath) {
         throw new Error(
           `Vrowzer reserved define ${VROWZER_PREVIEW_BASE_PATH_DEFINE} must be ${serializedBasePath}, received ${JSON.stringify(resolvedBasePath)}`
+        )
+      }
+
+      const resolvedServiceWorkerScope = config.define?.[VROWZER_SERVICE_WORKER_SCOPE_DEFINE]
+      if (resolvedServiceWorkerScope !== serializedServiceWorkerScope) {
+        throw new Error(
+          `Vrowzer reserved define ${VROWZER_SERVICE_WORKER_SCOPE_DEFINE} must be ${serializedServiceWorkerScope}, received ${JSON.stringify(resolvedServiceWorkerScope)}`
         )
       }
     }

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -1,7 +1,22 @@
-import { describe, expect, test } from 'vite-plus/test'
+import { beforeEach, describe, expect, test, vi } from 'vite-plus/test'
+
+type ServiceWorkerPluginFactory = (options: unknown) => { name: string }
+
+const serviceWorkerPluginFactory = vi.hoisted(() =>
+  vi.fn<ServiceWorkerPluginFactory>(_options => ({ name: 'unplugin-service-worker' }))
+)
+
+vi.mock('@vrowzer/unplugin-service-worker/vite', () => ({
+  default: serviceWorkerPluginFactory
+}))
+
 import { Vrowzer } from './index.ts'
 
 describe('Vrowzer', () => {
+  beforeEach(() => {
+    serviceWorkerPluginFactory.mockClear()
+  })
+
   test('returns array of 7 plugins with auto mode (default)', () => {
     const plugins = Vrowzer()
     expect(plugins).toHaveLength(7)
@@ -46,5 +61,33 @@ describe('Vrowzer', () => {
     const plugins = Vrowzer()
     // unplugin-service-worker generates a plugin with 'unplugin-service-worker' in the name
     expect(plugins.some((p: any) => p.name?.includes('service-worker'))).toBe(true)
+  })
+
+  test('uses the default scope for the service-worker response header', () => {
+    Vrowzer()
+
+    expect(serviceWorkerPluginFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entry: expect.any(String),
+        serviceWorkerAllowed: '/',
+        format: 'esm'
+      })
+    )
+  })
+
+  test('uses a custom scope for the service-worker response header', () => {
+    Vrowzer({ serviceWorkerScope: '/app/' })
+
+    expect(serviceWorkerPluginFactory).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceWorkerAllowed: '/app/' })
+    )
+  })
+
+  test('forwards a custom service worker entry', () => {
+    Vrowzer({ serviceWorkerEntry: '/custom/service-worker.ts' })
+
+    expect(serviceWorkerPluginFactory).toHaveBeenCalledWith(
+      expect.objectContaining({ entry: '/custom/service-worker.ts', format: 'esm' })
+    )
   })
 })

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -163,7 +163,7 @@ export function Vrowzer(options: VrowzerOptions = {}): Plugin[] {
     apply: 'serve'
   } as unknown as Plugin
   const serviceWorkerPlugin = ServiceWorker({
-    serviceWorkerAllowed: '/',
+    serviceWorkerAllowed: resolvedOptions.serviceWorkerScope,
     format: 'esm',
     ...(resolvedOptions.serviceWorkerEntry ? { entry: resolvedOptions.serviceWorkerEntry } : {})
   }) as unknown as Plugin

--- a/packages/vite-plugin/src/options.ts
+++ b/packages/vite-plugin/src/options.ts
@@ -98,8 +98,10 @@ export interface VrowzerOptions {
    */
   basePath?: string
   /**
-   * The scope for the service worker of Vrowzer, which determines the range of URLs that the service worker will control.
-   * This registration scope is independent of the preview `basePath`.
+   * The scope for the service worker of Vrowzer, which determines the range of URLs that
+   * the service worker will control and the `Service-Worker-Allowed` response header.
+   * The value is injected into the Vrowzer runtime, so its corresponding option can be
+   * omitted. This registration scope is independent of the preview `basePath`.
    *
    * @default '/' (the entire origin)
    */

--- a/packages/vrowzer/README.md
+++ b/packages/vrowzer/README.md
@@ -101,7 +101,17 @@ const vrowzer = Vrowzer()
 
 The runtime `basePath` remains available for compatibility and for usage without the plugin. If both the plugin and runtime values are provided, their canonical paths must match or `Vrowzer()` throws. Without either value, the preview path is `/__preview__/`.
 
-`serviceWorkerScope` controls which pages the browser allows the Service Worker to control. It does not set the preview URL; that is the role of `basePath`.
+`serviceWorkerScope` controls which pages the browser allows the Service Worker to control. When `@vrowzer/vite-plugin` is used, configure the scope on the plugin so the registration and `Service-Worker-Allowed` response header use the same value. The runtime option can then be omitted:
+
+```ts
+// vite.config.ts
+VrowzerPlugin({ serviceWorkerScope: '/app/' })
+
+// application.ts
+const vrowzer = Vrowzer()
+```
+
+The runtime `serviceWorkerScope` remains available for compatibility and for builds without the plugin. If both values are provided, they must match or `Vrowzer()` throws before registration. Without either value, the scope defaults to `/`. The scope does not set the preview URL; that is the role of `basePath`.
 
 **Options:**
 
@@ -109,7 +119,7 @@ The runtime `basePath` remains available for compatibility and for usage without
 | ---------------------- | -------- | --------------------------------- | ------------------------------------------------- |
 | `basePath`             | `string` | Plugin value or `'/__preview__/'` | Preview URL pathname; must match the plugin value  |
 | `serviceWorkerVersion` | `string` | `'vrowzer-v1'`                    | SW version for cache management                   |
-| `serviceWorkerScope`   | `string` | `'/'`                             | SW registration scope, independent of `basePath`  |
+| `serviceWorkerScope`   | `string` | Plugin value or `'/'`             | SW registration scope; must match the plugin value |
 
 ### Instance Methods
 

--- a/packages/vrowzer/docs/default/interfaces/VrowzerOptions.md
+++ b/packages/vrowzer/docs/default/interfaces/VrowzerOptions.md
@@ -13,5 +13,5 @@ export interface VrowzerOptions
 | Name | Type | Description |
 | --- | --- | --- |
 | `basePath` _(optional)_ | `string` | Preview URL pathname. When `@vrowzer/vite-plugin` is used, its `basePath` is injected and this option can be omitted. If both are provided, their canonical values must match. Without the plugin, this option defaults to `'/__preview__/'`. |
-| `serviceWorkerScope` _(optional)_ | `string` | Service Worker registration scope, independent of `basePath` (default: '/') |
+| `serviceWorkerScope` _(optional)_ | `string` | Service Worker registration scope, independent of `basePath`. When `@vrowzer/vite-plugin` is used, its `serviceWorkerScope` is injected and this option can be omitted. If both are provided, their values must match. Without the plugin, this option defaults to `'/'`. |
 | `serviceWorkerVersion` _(optional)_ | `string` | Service Worker version for cache management (default: 'vrowzer-v1') |

--- a/packages/vrowzer/integration/custom-base.integration-test.ts
+++ b/packages/vrowzer/integration/custom-base.integration-test.ts
@@ -13,6 +13,7 @@ const HOST_BASE = '/app/'
 const PREVIEW_BASE = '/app/__preview__/'
 const PREVIEW_MODULE = `${PREVIEW_BASE}main.js`
 const PREVIEW_TEXT = 'Custom base preview works'
+const SERVICE_WORKER_SCOPE = '/app/'
 
 type TestMode = 'development' | 'build'
 type TestServer = PreviewServer | ViteDevServer
@@ -84,6 +85,27 @@ async function expectPreviewContent(page: Page): Promise<void> {
   expect(moduleResponse.body).toContain(PREVIEW_TEXT)
 }
 
+async function expectServiceWorkerRegistration(page: Page): Promise<void> {
+  const registration = await page.evaluate(async scope => {
+    const result = await navigator.serviceWorker.getRegistration(scope)
+    const worker = result?.active ?? result?.waiting ?? result?.installing
+    if (!result || !worker) {
+      return undefined
+    }
+    return { scope: result.scope, scriptURL: worker.scriptURL }
+  }, SERVICE_WORKER_SCOPE)
+
+  if (!registration) {
+    throw new Error(`No Service Worker registration found for ${SERVICE_WORKER_SCOPE}`)
+  }
+
+  expect(new URL(registration.scope).pathname).toBe(SERVICE_WORKER_SCOPE)
+
+  const response = await fetch(registration.scriptURL)
+  expect(response.status).toBe(200)
+  expect(response.headers.get('Service-Worker-Allowed')).toBe(SERVICE_WORKER_SCOPE)
+}
+
 async function runScenario(mode: TestMode): Promise<void> {
   let browser: Browser | undefined
   let context: BrowserContext | undefined
@@ -101,10 +123,12 @@ async function runScenario(mode: TestMode): Promise<void> {
     await page.goto(`${getServerOrigin(server)}${HOST_BASE}`)
     await waitForReady(page)
     await expectPreviewContent(page)
+    await expectServiceWorkerRegistration(page)
 
     await page.reload()
     await waitForReady(page)
     await expectPreviewContent(page)
+    await expectServiceWorkerRegistration(page)
 
     expect(logs.join('\n')).not.toMatch(
       /Service Worker (?:listen\(\) did not complete|registration error)/

--- a/packages/vrowzer/integration/custom-base/vite.config.ts
+++ b/packages/vrowzer/integration/custom-base/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     VrowzerPlugin({
       auto: false,
       basePath: '/app/__preview__/',
+      serviceWorkerScope: '/app/',
       serviceWorkerEntry: resolve(__dirname, '../../dist/service-worker.ts')
     })
   ]

--- a/packages/vrowzer/src/index.ts
+++ b/packages/vrowzer/src/index.ts
@@ -54,6 +54,7 @@ import {
 } from '@vrowzer/vite-dev-server/messages'
 import { getServiceWorker, getController, initServiceWorker } from './controller.ts'
 import { resolvePreviewBasePath } from './preview-base.ts'
+import { resolveServiceWorkerScope } from './service-worker-scope.ts'
 
 import type { Emittable } from '@kazupon/jts-utils/event/emitter'
 import type { FileSystemPublisher } from '@vrowzer/fs/watcher'
@@ -73,7 +74,13 @@ export interface VrowzerOptions {
   basePath?: string
   /** Service Worker version for cache management (default: 'vrowzer-v1') */
   serviceWorkerVersion?: string
-  /** Service Worker registration scope, independent of `basePath` (default: '/') */
+  /**
+   * Service Worker registration scope, independent of `basePath`.
+   *
+   * When `@vrowzer/vite-plugin` is used, its `serviceWorkerScope` is injected and this
+   * option can be omitted. If both are provided, their values must match. Without the
+   * plugin, this option defaults to `'/'`.
+   */
   serviceWorkerScope?: string
 }
 
@@ -150,7 +157,7 @@ function resolveVrowzerOptions(options: VrowzerOptions): ResolvedVrowzerOptions 
   return {
     basePath: resolvePreviewBasePath(options.basePath),
     serviceWorkerVersion: options.serviceWorkerVersion ?? 'vrowzer-v1',
-    serviceWorkerScope: options.serviceWorkerScope ?? '/'
+    serviceWorkerScope: resolveServiceWorkerScope(options.serviceWorkerScope)
   }
 }
 

--- a/packages/vrowzer/src/service-worker-scope.test.ts
+++ b/packages/vrowzer/src/service-worker-scope.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vite-plus/test'
+import { DEFAULT_SERVICE_WORKER_SCOPE, resolveServiceWorkerScope } from './service-worker-scope.ts'
+
+describe('resolveServiceWorkerScope', () => {
+  test('falls back to the default without runtime or injected values', () => {
+    expect(resolveServiceWorkerScope()).toBe(DEFAULT_SERVICE_WORKER_SCOPE)
+  })
+
+  test('uses the runtime value without an injected value', () => {
+    expect(resolveServiceWorkerScope('/runtime/', undefined)).toBe('/runtime/')
+  })
+
+  test('uses the injected value without a runtime value', () => {
+    expect(resolveServiceWorkerScope(undefined, '/injected/')).toBe('/injected/')
+  })
+
+  test('accepts equal runtime and injected values', () => {
+    expect(resolveServiceWorkerScope('/app/', '/app/')).toBe('/app/')
+  })
+
+  test('rejects different runtime and injected values', () => {
+    expect(() => resolveServiceWorkerScope('/runtime/', '/injected/')).toThrow(
+      'Vrowzer serviceWorkerScope "/runtime/" does not match @vrowzer/vite-plugin serviceWorkerScope "/injected/". Configure serviceWorkerScope in vite.config.ts.'
+    )
+  })
+})

--- a/packages/vrowzer/src/service-worker-scope.ts
+++ b/packages/vrowzer/src/service-worker-scope.ts
@@ -1,0 +1,27 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+export const DEFAULT_SERVICE_WORKER_SCOPE = '/'
+
+declare const __VROWZER_INTERNAL_SERVICE_WORKER_SCOPE__: string
+
+function getInjectedServiceWorkerScope(): string | undefined {
+  return typeof __VROWZER_INTERNAL_SERVICE_WORKER_SCOPE__ === 'string'
+    ? __VROWZER_INTERNAL_SERVICE_WORKER_SCOPE__
+    : undefined
+}
+
+export function resolveServiceWorkerScope(
+  runtimeScope?: string,
+  injectedScope: string | undefined = getInjectedServiceWorkerScope()
+): string {
+  if (runtimeScope !== undefined && injectedScope !== undefined && runtimeScope !== injectedScope) {
+    throw new Error(
+      `Vrowzer serviceWorkerScope ${JSON.stringify(runtimeScope)} does not match @vrowzer/vite-plugin serviceWorkerScope ${JSON.stringify(injectedScope)}. Configure serviceWorkerScope in vite.config.ts.`
+    )
+  }
+
+  return injectedScope ?? runtimeScope ?? DEFAULT_SERVICE_WORKER_SCOPE
+}


### PR DESCRIPTION
## Summary

Uses the resolved `serviceWorkerScope` from `@vrowzer/vite-plugin` as the single source of truth. The plugin now injects it into the runtime and applies the same value to dev, preview, and bundled Service Worker response headers.

Runtime-only configuration remains supported when the plugin is absent. Explicit plugin/runtime mismatches now fail before registration.

## Verification

- `vp check`
- `vp run build`
- `vp run test`
- `vp run test:e2e:build`

Adds dev/build integration coverage for `/app/`.

Closes #18