### PR TITLE
fix(vite-plugin): prevent Vite 8 optimizer crash

### DIFF
--- a/e2e/vite-vanilla/vite.config.ts
+++ b/e2e/vite-vanilla/vite.config.ts
@@ -3,5 +3,9 @@ import { Vrowzer, VrowzerManifest } from '@vrowzer/vite-plugin'
 import { defineConfig } from 'vite-plus'
 
 export default defineConfig({
+  // Exercise the same dependency optimizer path used by an npm-installed package.
+  optimizeDeps: {
+    include: ['vrowzer']
+  },
   plugins: [VrowzerManifest(), yaml(), Vrowzer({ auto: false })]
 })

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -263,6 +263,7 @@ Auto-extracts user plugins from `vite.config.ts` using OXC parser, then pre-bund
 - Resolves `@vrowzer/*` imports from the plugin's own dependency graph
 - Inlines `readFileSync()` and `createRequire()` calls for Worker compatibility
 - Maps `vite` imports to `@vrowzer/vite-dev-server/vite`
+- Excludes `@vrowzer/vite-dev-server` from host dependency pre-bundling while keeping `vrowzer` optimizable
 
 #### 3. Preview Guard Middleware (`vrowzer:server-middleware`)
 

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -12,6 +12,17 @@ vi.mock('@vrowzer/unplugin-service-worker/vite', () => ({
 
 import { Vrowzer } from './index.ts'
 
+import type { UserConfig } from 'vite'
+
+function resolveVrowzerConfig(options: Parameters<typeof Vrowzer>[0] = {}): UserConfig {
+  const plugin = Vrowzer(options).find(plugin => plugin.name === 'vrowzer:config')
+  if (!plugin || typeof plugin.config !== 'function') {
+    throw new Error('vrowzer:config plugin is missing its config hook')
+  }
+
+  return (plugin.config as () => UserConfig)()
+}
+
 describe('Vrowzer', () => {
   beforeEach(() => {
     serviceWorkerPluginFactory.mockClear()
@@ -40,6 +51,15 @@ describe('Vrowzer', () => {
   test('includes vrowzer:config plugin', () => {
     const plugins = Vrowzer()
     expect(plugins.some((p: any) => p.name === 'vrowzer:config')).toBe(true)
+  })
+
+  test.each([
+    ['auto mode', {}],
+    ['manual mode', { auto: false }]
+  ] as const)('excludes vite-dev-server from host dependency optimization in %s', (_, options) => {
+    const config = resolveVrowzerConfig(options)
+
+    expect(config.optimizeDeps?.exclude).toEqual(['@vrowzer/vite-dev-server'])
   })
 
   test('includes vrowzer:server-middleware plugin', () => {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -98,6 +98,9 @@ export function Vrowzer(options: VrowzerOptions = {}): Plugin[] {
       ]
 
       return {
+        optimizeDeps: {
+          exclude: ['@vrowzer/vite-dev-server']
+        },
         resolve: {
           alias: [{ find: /^vite$/, replacement: '@vrowzer/vite-dev-server/vite' }]
         },


### PR DESCRIPTION
## Summary

Prevent Vite 8's Rolldown dependency optimizer from treating Vrowzer's `?raw` client imports as file paths. The plugin now excludes only `@vrowzer/vite-dev-server`, while keeping `vrowzer` eligible for pre-bundling.

The vanilla E2E fixture explicitly includes the linked `vrowzer` package so CI covers the npm-installed optimizer path that previously failed. Unit coverage and plugin documentation are updated.

## Validation

- `vp check`
- `vp test run`
- `vp run test:e2e`

Closes #13