### PR TITLE
fix(vrowzer): sync service worker version

### DIFF
--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -94,6 +94,26 @@ const vrowzer = Vrowzer()
 
 The runtime `Vrowzer({ serviceWorkerScope })` option remains available for compatibility and for builds without the plugin. If both values are provided, they must match or `Vrowzer()` throws before registration. Without either value, the scope and response header default to `/`.
 
+### Service Worker version
+
+The plugin's `serviceWorkerVersion` is the source of truth for the version expected by the application and reported by the Service Worker. Configure it once in `vite.config.ts`; application code can call `Vrowzer()` without repeating the value:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  plugins: [Vrowzer({ serviceWorkerVersion: 'app-v2' })]
+})
+```
+
+```ts
+// application code
+import { Vrowzer } from 'vrowzer'
+
+const vrowzer = Vrowzer()
+```
+
+The runtime `Vrowzer({ serviceWorkerVersion })` option remains available for compatibility and for builds without the plugin. If both values are provided, they must match or `Vrowzer()` throws before Service Worker registration. Without either value, the version defaults to `vrowzer-v1`. The resolved version is also reflected in the Service Worker script URL, so changing it may trigger a Service Worker update.
+
 When the host page and preview content are in different directories, use `manifest.sourceDir`:
 
 ```ts
@@ -194,7 +214,7 @@ Vrowzer({
   serviceWorkerScope: '/',
 
   // Service Worker version for cache management
-  // Default: 'SERVICE_WORKER_VERSION'
+  // Default: 'vrowzer-v1'
   serviceWorkerVersion: 'my-app-v1',
 
   // Explicit Service Worker entry file path
@@ -216,7 +236,7 @@ Vrowzer({
 | `experimental`         | `VrowzerExperimentalOptions` | `undefined`                               | Experimental features. Currently supports `ide`.                                          |
 | `basePath`             | `string`                     | `'/__preview__/'`                         | Preview URL pathname shared with the application and Service Worker bundles.              |
 | `serviceWorkerScope`   | `string`                     | `'/'`                                     | Registration scope and `Service-Worker-Allowed` header injected into the runtime.          |
-| `serviceWorkerVersion` | `string`                     | `'SERVICE_WORKER_VERSION'`                | Version string for Service Worker cache management.                                       |
+| `serviceWorkerVersion` | `string`                     | `'vrowzer-v1'`                            | Version shared with the application and Service Worker bundles.                           |
 | `serviceWorkerEntry`   | `string`                     | Resolved path to `vrowzer/service-worker` | Explicit Service Worker entry file path.                                                  |
 | `resolve`              | `{ alias?: Alias[] }`        | `undefined`                               | Worker-specific resolve settings passed to the internal Vite dev server.                  |
 

--- a/packages/vite-plugin/src/env.test.ts
+++ b/packages/vite-plugin/src/env.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from 'vite-plus/test'
 import {
   envPlugin,
   VROWZER_PREVIEW_BASE_PATH_DEFINE,
-  VROWZER_SERVICE_WORKER_SCOPE_DEFINE
+  VROWZER_SERVICE_WORKER_SCOPE_DEFINE,
+  VROWZER_SERVICE_WORKER_VERSION_DEFINE
 } from './env.ts'
 import { resolveOptions } from './options.ts'
 
@@ -120,11 +121,42 @@ describe('envPlugin', () => {
     expect(result.define[VROWZER_SERVICE_WORKER_SCOPE_DEFINE]).toBe(JSON.stringify('/app/'))
   })
 
-  test('configResolved accepts the injected preview base path', () => {
+  test('config hook defines the default service worker version', () => {
+    const plugin = createPlugin()
+    const result = (plugin as any).config({}, { command: 'serve' })
+
+    expect(result.define[VROWZER_SERVICE_WORKER_VERSION_DEFINE]).toBe(JSON.stringify('vrowzer-v1'))
+  })
+
+  test('config hook defines a custom service worker version', () => {
+    const plugin = createPlugin({ serviceWorkerVersion: 'app-v2' })
+    const result = (plugin as any).config({}, { command: 'serve' })
+
+    expect(result.define[VROWZER_SERVICE_WORKER_VERSION_DEFINE]).toBe(JSON.stringify('app-v2'))
+  })
+
+  test('config hook keeps debug and all reserved defines together', () => {
+    const plugin = createPlugin({
+      basePath: '/app/__preview__/',
+      serviceWorkerScope: '/app/',
+      serviceWorkerVersion: 'app-v2'
+    })
+    const result = (plugin as any).config({}, { command: 'serve' })
+
+    expect(result.define).toMatchObject({
+      'import.meta.env.DEBUG': expect.any(String),
+      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/app/__preview__/'),
+      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/app/'),
+      [VROWZER_SERVICE_WORKER_VERSION_DEFINE]: JSON.stringify('app-v2')
+    })
+  })
+
+  test('configResolved accepts all injected reserved values', () => {
     const plugin = createPlugin()
     const define = {
       [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/'),
-      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/')
+      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/'),
+      [VROWZER_SERVICE_WORKER_VERSION_DEFINE]: JSON.stringify('vrowzer-v1')
     }
 
     expect(() => (plugin as any).configResolved({ define })).not.toThrow()
@@ -134,7 +166,8 @@ describe('envPlugin', () => {
     const plugin = createPlugin()
     const define = {
       [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/other/'),
-      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/')
+      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/'),
+      [VROWZER_SERVICE_WORKER_VERSION_DEFINE]: JSON.stringify('vrowzer-v1')
     }
 
     expect(() => (plugin as any).configResolved({ define })).toThrow(
@@ -146,7 +179,8 @@ describe('envPlugin', () => {
     const plugin = createPlugin()
     const define = {
       [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/'),
-      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/other/')
+      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/other/'),
+      [VROWZER_SERVICE_WORKER_VERSION_DEFINE]: JSON.stringify('vrowzer-v1')
     }
 
     expect(() => (plugin as any).configResolved({ define })).toThrow(
@@ -157,11 +191,37 @@ describe('envPlugin', () => {
   test('configResolved rejects a missing service worker scope', () => {
     const plugin = createPlugin()
     const define = {
-      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/')
+      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/'),
+      [VROWZER_SERVICE_WORKER_VERSION_DEFINE]: JSON.stringify('vrowzer-v1')
     }
 
     expect(() => (plugin as any).configResolved({ define })).toThrow(
       `Vrowzer reserved define ${VROWZER_SERVICE_WORKER_SCOPE_DEFINE}`
+    )
+  })
+
+  test('configResolved rejects an overridden service worker version', () => {
+    const plugin = createPlugin()
+    const define = {
+      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/'),
+      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/'),
+      [VROWZER_SERVICE_WORKER_VERSION_DEFINE]: JSON.stringify('other-version')
+    }
+
+    expect(() => (plugin as any).configResolved({ define })).toThrow(
+      `Vrowzer reserved define ${VROWZER_SERVICE_WORKER_VERSION_DEFINE} must be ${JSON.stringify('vrowzer-v1')}, received ${JSON.stringify(JSON.stringify('other-version'))}`
+    )
+  })
+
+  test('configResolved rejects a missing service worker version', () => {
+    const plugin = createPlugin()
+    const define = {
+      [VROWZER_PREVIEW_BASE_PATH_DEFINE]: JSON.stringify('/__preview__/'),
+      [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: JSON.stringify('/')
+    }
+
+    expect(() => (plugin as any).configResolved({ define })).toThrow(
+      `Vrowzer reserved define ${VROWZER_SERVICE_WORKER_VERSION_DEFINE}`
     )
   })
 })

--- a/packages/vite-plugin/src/env.ts
+++ b/packages/vite-plugin/src/env.ts
@@ -21,6 +21,7 @@ import type { ResolvedVrowzerOptions } from './options.ts'
 const debug = createDebug('vite-plugin-vrowzer:env')
 export const VROWZER_PREVIEW_BASE_PATH_DEFINE = '__VROWZER_INTERNAL_PREVIEW_BASE_PATH__'
 export const VROWZER_SERVICE_WORKER_SCOPE_DEFINE = '__VROWZER_INTERNAL_SERVICE_WORKER_SCOPE__'
+export const VROWZER_SERVICE_WORKER_VERSION_DEFINE = '__VROWZER_INTERNAL_SERVICE_WORKER_VERSION__'
 
 // Resolve picocolors browser version path.
 // picocolors doesn't export the browser file via package.json exports,
@@ -33,6 +34,7 @@ const picocolorsBrowser = resolve(
 export function envPlugin(options: ResolvedVrowzerOptions): Plugin {
   const serializedBasePath = JSON.stringify(options.basePath)
   const serializedServiceWorkerScope = JSON.stringify(options.serviceWorkerScope)
+  const serializedServiceWorkerVersion = JSON.stringify(options.serviceWorkerVersion)
   return {
     name: 'vrowzer:env',
     // Rolldown native inject: inject `process` global for browser/Worker environments.
@@ -53,7 +55,8 @@ export function envPlugin(options: ResolvedVrowzerOptions): Plugin {
         define: {
           'import.meta.env.DEBUG': JSON.stringify(process.env.DEBUG || ''),
           [VROWZER_PREVIEW_BASE_PATH_DEFINE]: serializedBasePath,
-          [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: serializedServiceWorkerScope
+          [VROWZER_SERVICE_WORKER_SCOPE_DEFINE]: serializedServiceWorkerScope,
+          [VROWZER_SERVICE_WORKER_VERSION_DEFINE]: serializedServiceWorkerVersion
         },
         resolve: {
           alias: resolveAliases({
@@ -97,6 +100,13 @@ export function envPlugin(options: ResolvedVrowzerOptions): Plugin {
       if (resolvedServiceWorkerScope !== serializedServiceWorkerScope) {
         throw new Error(
           `Vrowzer reserved define ${VROWZER_SERVICE_WORKER_SCOPE_DEFINE} must be ${serializedServiceWorkerScope}, received ${JSON.stringify(resolvedServiceWorkerScope)}`
+        )
+      }
+
+      const resolvedServiceWorkerVersion = config.define?.[VROWZER_SERVICE_WORKER_VERSION_DEFINE]
+      if (resolvedServiceWorkerVersion !== serializedServiceWorkerVersion) {
+        throw new Error(
+          `Vrowzer reserved define ${VROWZER_SERVICE_WORKER_VERSION_DEFINE} must be ${serializedServiceWorkerVersion}, received ${JSON.stringify(resolvedServiceWorkerVersion)}`
         )
       }
     }

--- a/packages/vite-plugin/src/options.test.ts
+++ b/packages/vite-plugin/src/options.test.ts
@@ -8,7 +8,7 @@ describe('resolveOptions', () => {
     expect(resolved.auto).toBe(true)
     expect(resolved.basePath).toBe('/__preview__/')
     expect(resolved.serviceWorkerScope).toBe('/')
-    expect(resolved.serviceWorkerVersion).toBe('SERVICE_WORKER_VERSION')
+    expect(resolved.serviceWorkerVersion).toBe('vrowzer-v1')
   })
 
   test('respects auto: false', () => {
@@ -49,5 +49,9 @@ describe('resolveOptions', () => {
     const resolved = resolveOptions({ serviceWorkerVersion: 'v2.0.0' })
 
     expect(resolved.serviceWorkerVersion).toBe('v2.0.0')
+  })
+
+  test.each(['', ' app v2 ', 'version/β+二'])('preserves opaque serviceWorkerVersion %j', value => {
+    expect(resolveOptions({ serviceWorkerVersion: value }).serviceWorkerVersion).toBe(value)
   })
 })

--- a/packages/vite-plugin/src/options.ts
+++ b/packages/vite-plugin/src/options.ts
@@ -12,6 +12,7 @@
 import { fileURLToPath } from 'node:url'
 
 const DEFAULT_BASE_PATH = '/__preview__/'
+const DEFAULT_SERVICE_WORKER_VERSION = 'vrowzer-v1'
 
 export interface Alias {
   find: string | RegExp
@@ -108,8 +109,9 @@ export interface VrowzerOptions {
   serviceWorkerScope?: string
   /**
    * The version of the service worker for Vrowzer, which can be used to manage updates and cache invalidation for the preview system.
+   * This is the source of truth for both the application and Service Worker bundles.
    *
-   * @default 'SERVICE_WORKER_VERSION'
+   * @default 'vrowzer-v1'
    */
   serviceWorkerVersion?: string
   /**
@@ -197,7 +199,7 @@ export function resolveOptions(options: VrowzerOptions): ResolvedVrowzerOptions 
     },
     basePath: normalizeBasePath(options.basePath ?? DEFAULT_BASE_PATH),
     serviceWorkerScope: options.serviceWorkerScope ?? '/',
-    serviceWorkerVersion: options.serviceWorkerVersion ?? 'SERVICE_WORKER_VERSION',
+    serviceWorkerVersion: options.serviceWorkerVersion ?? DEFAULT_SERVICE_WORKER_VERSION,
     serviceWorkerEntry: options.serviceWorkerEntry ?? resolveDefaultServiceWorkerEntry(),
     resolve: options.resolve
   }

--- a/packages/vrowzer/README.md
+++ b/packages/vrowzer/README.md
@@ -113,13 +113,25 @@ const vrowzer = Vrowzer()
 
 The runtime `serviceWorkerScope` remains available for compatibility and for builds without the plugin. If both values are provided, they must match or `Vrowzer()` throws before registration. Without either value, the scope defaults to `/`. The scope does not set the preview URL; that is the role of `basePath`.
 
+`serviceWorkerVersion` identifies the Service Worker version expected by the controller and reported by the worker. When `@vrowzer/vite-plugin` is used, configure the version on the plugin and omit the runtime option:
+
+```ts
+// vite.config.ts
+VrowzerPlugin({ serviceWorkerVersion: 'app-v2' })
+
+// application.ts
+const vrowzer = Vrowzer()
+```
+
+The runtime `serviceWorkerVersion` remains available for compatibility and for builds without the plugin. If both values are provided, they must match or `Vrowzer()` throws before registration. Without either value, the version defaults to `vrowzer-v1`. The resolved version is also reflected in the Service Worker script URL, so changing it may trigger a Service Worker update.
+
 **Options:**
 
-| Option                 | Type     | Default                           | Description                                       |
-| ---------------------- | -------- | --------------------------------- | ------------------------------------------------- |
-| `basePath`             | `string` | Plugin value or `'/__preview__/'` | Preview URL pathname; must match the plugin value  |
-| `serviceWorkerVersion` | `string` | `'vrowzer-v1'`                    | SW version for cache management                   |
-| `serviceWorkerScope`   | `string` | Plugin value or `'/'`             | SW registration scope; must match the plugin value |
+| Option                 | Type     | Default                           | Description                                            |
+| ---------------------- | -------- | --------------------------------- | ------------------------------------------------------ |
+| `basePath`             | `string` | Plugin value or `'/__preview__/'` | Preview URL pathname; must match the plugin value       |
+| `serviceWorkerVersion` | `string` | Plugin value or `'vrowzer-v1'`    | SW version; must match the plugin value                 |
+| `serviceWorkerScope`   | `string` | Plugin value or `'/'`             | SW registration scope; must match the plugin value      |
 
 ### Instance Methods
 

--- a/packages/vrowzer/docs/default/interfaces/VrowzerOptions.md
+++ b/packages/vrowzer/docs/default/interfaces/VrowzerOptions.md
@@ -14,4 +14,4 @@ export interface VrowzerOptions
 | --- | --- | --- |
 | `basePath` _(optional)_ | `string` | Preview URL pathname. When `@vrowzer/vite-plugin` is used, its `basePath` is injected and this option can be omitted. If both are provided, their canonical values must match. Without the plugin, this option defaults to `'/__preview__/'`. |
 | `serviceWorkerScope` _(optional)_ | `string` | Service Worker registration scope, independent of `basePath`. When `@vrowzer/vite-plugin` is used, its `serviceWorkerScope` is injected and this option can be omitted. If both are provided, their values must match. Without the plugin, this option defaults to `'/'`. |
-| `serviceWorkerVersion` _(optional)_ | `string` | Service Worker version for cache management (default: 'vrowzer-v1') |
+| `serviceWorkerVersion` _(optional)_ | `string` | Service Worker version for cache management. When `@vrowzer/vite-plugin` is used, its `serviceWorkerVersion` is injected and this option can be omitted. If both are provided, their values must match. Without the plugin, this option defaults to `'vrowzer-v1'`. |

--- a/packages/vrowzer/integration/custom-base.integration-test.ts
+++ b/packages/vrowzer/integration/custom-base.integration-test.ts
@@ -1,4 +1,5 @@
 import { chromium } from '@playwright/test'
+import { V_SW_VERSION } from '@vrowzer/service-worker/protocols'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { build, createServer, preview } from 'vite'
@@ -14,6 +15,9 @@ const PREVIEW_BASE = '/app/__preview__/'
 const PREVIEW_MODULE = `${PREVIEW_BASE}main.js`
 const PREVIEW_TEXT = 'Custom base preview works'
 const SERVICE_WORKER_SCOPE = '/app/'
+const SERVICE_WORKER_VERSION = 'app-v2'
+const SERVICE_WORKER_VERSION_QUERY = 'vrowzer-version'
+const SERVICE_WORKER_VERSION_DEFINE = '__VROWZER_INTERNAL_SERVICE_WORKER_VERSION__'
 
 type TestMode = 'development' | 'build'
 type TestServer = PreviewServer | ViteDevServer
@@ -85,7 +89,7 @@ async function expectPreviewContent(page: Page): Promise<void> {
   expect(moduleResponse.body).toContain(PREVIEW_TEXT)
 }
 
-async function expectServiceWorkerRegistration(page: Page): Promise<void> {
+async function expectServiceWorkerRegistration(page: Page, mode: TestMode): Promise<void> {
   const registration = await page.evaluate(async scope => {
     const result = await navigator.serviceWorker.getRegistration(scope)
     const worker = result?.active ?? result?.waiting ?? result?.installing
@@ -100,10 +104,56 @@ async function expectServiceWorkerRegistration(page: Page): Promise<void> {
   }
 
   expect(new URL(registration.scope).pathname).toBe(SERVICE_WORKER_SCOPE)
+  const scriptURL = new URL(registration.scriptURL)
+  expect(scriptURL.searchParams.get(SERVICE_WORKER_VERSION_QUERY)).toBe(SERVICE_WORKER_VERSION)
+  if (mode === 'development') {
+    expect(scriptURL.searchParams.get('sw')).toBe('service_worker_file')
+  }
 
   const response = await fetch(registration.scriptURL)
   expect(response.status).toBe(200)
   expect(response.headers.get('Service-Worker-Allowed')).toBe(SERVICE_WORKER_SCOPE)
+  const source = await response.text()
+  expect(source).toContain(SERVICE_WORKER_VERSION)
+  expect(source).not.toContain(SERVICE_WORKER_VERSION_DEFINE)
+
+  const versionResponse = await page.evaluate(
+    async ({ messageType, scope }) => {
+      const result = await navigator.serviceWorker.getRegistration(scope)
+      const worker = result?.active ?? result?.waiting ?? result?.installing
+      if (!worker) {
+        throw new Error(`No Service Worker found for ${scope}`)
+      }
+
+      const channel = new MessageChannel()
+      return new Promise<{ type: string; version: string }>((resolve, reject) => {
+        const cleanup = () => {
+          clearTimeout(timer)
+          channel.port1.onmessage = null
+          channel.port1.onmessageerror = null
+          channel.port1.close()
+          channel.port2.close()
+        }
+        const timer = setTimeout(() => {
+          cleanup()
+          reject(new Error(`Service Worker ${messageType} response timed out`))
+        }, 5_000)
+
+        channel.port1.onmessage = event => {
+          cleanup()
+          resolve(event.data)
+        }
+        channel.port1.onmessageerror = () => {
+          cleanup()
+          reject(new Error(`Service Worker ${messageType} response could not be decoded`))
+        }
+        channel.port1.start()
+        worker.postMessage({ type: messageType }, [channel.port2])
+      })
+    },
+    { messageType: V_SW_VERSION, scope: SERVICE_WORKER_SCOPE }
+  )
+  expect(versionResponse).toEqual({ type: V_SW_VERSION, version: SERVICE_WORKER_VERSION })
 }
 
 async function runScenario(mode: TestMode): Promise<void> {
@@ -123,15 +173,15 @@ async function runScenario(mode: TestMode): Promise<void> {
     await page.goto(`${getServerOrigin(server)}${HOST_BASE}`)
     await waitForReady(page)
     await expectPreviewContent(page)
-    await expectServiceWorkerRegistration(page)
+    await expectServiceWorkerRegistration(page, mode)
 
     await page.reload()
     await waitForReady(page)
     await expectPreviewContent(page)
-    await expectServiceWorkerRegistration(page)
+    await expectServiceWorkerRegistration(page, mode)
 
     expect(logs.join('\n')).not.toMatch(
-      /Service Worker (?:listen\(\) did not complete|registration error)/
+      /\[pageerror\]|serviceWorkerVersion .*does not match|Service Worker (?:listen\(\) did not complete|registration error)/
     )
   } catch (error) {
     throw new Error(`Custom base ${mode} scenario failed\n${logs.join('\n')}`, { cause: error })

--- a/packages/vrowzer/integration/custom-base/vite.config.ts
+++ b/packages/vrowzer/integration/custom-base/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       auto: false,
       basePath: '/app/__preview__/',
       serviceWorkerScope: '/app/',
+      serviceWorkerVersion: 'app-v2',
       serviceWorkerEntry: resolve(__dirname, '../../dist/service-worker.ts')
     })
   ]

--- a/packages/vrowzer/src/index.ts
+++ b/packages/vrowzer/src/index.ts
@@ -55,6 +55,7 @@ import {
 import { getServiceWorker, getController, initServiceWorker } from './controller.ts'
 import { resolvePreviewBasePath } from './preview-base.ts'
 import { resolveServiceWorkerScope } from './service-worker-scope.ts'
+import { resolveServiceWorkerVersion, withServiceWorkerVersion } from './service-worker-version.ts'
 
 import type { Emittable } from '@kazupon/jts-utils/event/emitter'
 import type { FileSystemPublisher } from '@vrowzer/fs/watcher'
@@ -72,7 +73,13 @@ export interface VrowzerOptions {
    * this option defaults to `'/__preview__/'`.
    */
   basePath?: string
-  /** Service Worker version for cache management (default: 'vrowzer-v1') */
+  /**
+   * Service Worker version for cache management.
+   *
+   * When `@vrowzer/vite-plugin` is used, its `serviceWorkerVersion` is injected and this
+   * option can be omitted. If both are provided, their values must match. Without the
+   * plugin, this option defaults to `'vrowzer-v1'`.
+   */
   serviceWorkerVersion?: string
   /**
    * Service Worker registration scope, independent of `basePath`.
@@ -156,7 +163,7 @@ interface ResolvedVrowzerOptions {
 function resolveVrowzerOptions(options: VrowzerOptions): ResolvedVrowzerOptions {
   return {
     basePath: resolvePreviewBasePath(options.basePath),
-    serviceWorkerVersion: options.serviceWorkerVersion ?? 'vrowzer-v1',
+    serviceWorkerVersion: resolveServiceWorkerVersion(options.serviceWorkerVersion),
     serviceWorkerScope: resolveServiceWorkerScope(options.serviceWorkerScope)
   }
 }
@@ -400,7 +407,10 @@ function execScript(orig, origin) {
         // so when it resolves the SW is fully ready to accept MessageChannel connections.
         await Promise.all([
           initServiceWorker({
-            scriptURL: new URL('./service-worker.ts', import.meta.url),
+            scriptURL: withServiceWorkerVersion(
+              new URL('./service-worker.ts', import.meta.url),
+              resolved.serviceWorkerVersion
+            ),
             version: resolved.serviceWorkerVersion,
             scope: resolved.serviceWorkerScope
           }),

--- a/packages/vrowzer/src/service-worker-core.ts
+++ b/packages/vrowzer/src/service-worker-core.ts
@@ -26,14 +26,13 @@ import env from '@vrowzer/vite-dev-server/dist/client/env.mjs?raw'
 import { createServer } from '@vrowzer/vite-dev-server/service-worker'
 import { V_SW_LISTEN_READY, V_SW_LISTEN_READY_PING } from '@vrowzer/vite-dev-server/messages'
 import { resolvePreviewBasePath } from './preview-base.ts'
+import { resolveServiceWorkerVersionForWorker } from './service-worker-version.ts'
 
 import type { FileSystemSyncMessage } from '@vrowzer/fs/watcher'
 import type { CreateServerOptions } from '@vrowzer/vite-dev-server/service-worker'
 import type { Plugin } from '@vrowzer/vite-dev-server/vite'
 
 declare const self: ServiceWorkerGlobalScope
-
-const SW_VERSION = 'vrowzer-v1'
 
 export async function initServiceWorker(options?: { plugins?: Plugin[] }) {
   // Initial volume setup: client files + public dir
@@ -46,8 +45,9 @@ export async function initServiceWorker(options?: { plugins?: Plugin[] }) {
 
   const subscriber = createFileSystemSubscriber(fs)
   const previewBase = resolvePreviewBasePath()
+  const serviceWorkerVersion = resolveServiceWorkerVersionForWorker(self.location.href)
   const serverOptions = {
-    version: SW_VERSION,
+    version: serviceWorkerVersion,
     basePath: previewBase,
     ...(options?.plugins ? { plugins: options.plugins } : {}),
     watcherFactory: () => subscriber.watcher as any

--- a/packages/vrowzer/src/service-worker-version.test.ts
+++ b/packages/vrowzer/src/service-worker-version.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'vite-plus/test'
+import {
+  DEFAULT_SERVICE_WORKER_VERSION,
+  resolveServiceWorkerVersion,
+  resolveServiceWorkerVersionForWorker,
+  VROWZER_SERVICE_WORKER_VERSION_QUERY,
+  withServiceWorkerVersion
+} from './service-worker-version.ts'
+
+describe('resolveServiceWorkerVersion', () => {
+  test('falls back to the default without runtime or injected values', () => {
+    expect(resolveServiceWorkerVersion()).toBe(DEFAULT_SERVICE_WORKER_VERSION)
+  })
+
+  test('uses the runtime value without an injected value', () => {
+    expect(resolveServiceWorkerVersion('runtime-v2', undefined)).toBe('runtime-v2')
+  })
+
+  test('uses the injected value without a runtime value', () => {
+    expect(resolveServiceWorkerVersion(undefined, 'injected-v2')).toBe('injected-v2')
+  })
+
+  test('accepts equal runtime and injected values', () => {
+    expect(resolveServiceWorkerVersion('app-v2', 'app-v2')).toBe('app-v2')
+  })
+
+  test('rejects different runtime and injected values', () => {
+    expect(() => resolveServiceWorkerVersion('runtime-v2', 'plugin-v3')).toThrow(
+      'Vrowzer serviceWorkerVersion "runtime-v2" does not match @vrowzer/vite-plugin serviceWorkerVersion "plugin-v3". Configure serviceWorkerVersion in vite.config.ts.'
+    )
+  })
+
+  test.each(['', ' app v2 ', 'version/β+二'])('preserves opaque value %j', value => {
+    expect(resolveServiceWorkerVersion(value, undefined)).toBe(value)
+    expect(resolveServiceWorkerVersion(undefined, value)).toBe(value)
+    expect(resolveServiceWorkerVersion(value, value)).toBe(value)
+  })
+})
+
+describe('withServiceWorkerVersion', () => {
+  test('adds a version query to a URL without a query', () => {
+    const result = withServiceWorkerVersion(new URL('https://example.test/service-worker.js'), 'v2')
+
+    expect(result.searchParams.get(VROWZER_SERVICE_WORKER_VERSION_QUERY)).toBe('v2')
+  })
+
+  test('preserves existing query parameters', () => {
+    const result = withServiceWorkerVersion(
+      new URL('https://example.test/service-worker.ts?sw=service_worker_file&mode=dev'),
+      'v2'
+    )
+
+    expect(result.searchParams.get('sw')).toBe('service_worker_file')
+    expect(result.searchParams.get('mode')).toBe('dev')
+    expect(result.searchParams.get(VROWZER_SERVICE_WORKER_VERSION_QUERY)).toBe('v2')
+  })
+
+  test('replaces an existing version query without leaving duplicates', () => {
+    const result = withServiceWorkerVersion(
+      new URL('https://example.test/service-worker.js?vrowzer-version=old&vrowzer-version=stale'),
+      'current'
+    )
+
+    expect(result.searchParams.getAll(VROWZER_SERVICE_WORKER_VERSION_QUERY)).toEqual(['current'])
+  })
+
+  test.each(['', ' app v2 ', 'version/β+二'])('round-trips opaque version %j', version => {
+    const result = withServiceWorkerVersion(
+      new URL('https://example.test/service-worker.js'),
+      version
+    )
+
+    expect(result.searchParams.get(VROWZER_SERVICE_WORKER_VERSION_QUERY)).toBe(version)
+  })
+
+  test('returns a clone without mutating the input URL', () => {
+    const input = new URL('https://example.test/service-worker.js?existing=true')
+    const result = withServiceWorkerVersion(input, 'v2')
+
+    expect(result).not.toBe(input)
+    expect(input.searchParams.has(VROWZER_SERVICE_WORKER_VERSION_QUERY)).toBe(false)
+    expect(input.searchParams.get('existing')).toBe('true')
+  })
+})
+
+describe('resolveServiceWorkerVersionForWorker', () => {
+  test('falls back to the default without injected or query values', () => {
+    expect(resolveServiceWorkerVersionForWorker('https://example.test/service-worker.js')).toBe(
+      DEFAULT_SERVICE_WORKER_VERSION
+    )
+  })
+
+  test('uses the query value without an injected value', () => {
+    expect(
+      resolveServiceWorkerVersionForWorker(
+        'https://example.test/service-worker.js?vrowzer-version=query-v2',
+        undefined
+      )
+    ).toBe('query-v2')
+  })
+
+  test('uses the injected value without a query value', () => {
+    expect(
+      resolveServiceWorkerVersionForWorker('https://example.test/service-worker.js', 'injected-v2')
+    ).toBe('injected-v2')
+  })
+
+  test('accepts equal injected and query values', () => {
+    expect(
+      resolveServiceWorkerVersionForWorker(
+        'https://example.test/service-worker.js?vrowzer-version=app-v2',
+        'app-v2'
+      )
+    ).toBe('app-v2')
+  })
+
+  test('rejects different injected and query values', () => {
+    expect(() =>
+      resolveServiceWorkerVersionForWorker(
+        'https://example.test/service-worker.js?vrowzer-version=query-v2',
+        'injected-v3'
+      )
+    ).toThrow(
+      'Vrowzer injected serviceWorkerVersion "injected-v3" does not match Service Worker script URL version "query-v2".'
+    )
+  })
+
+  test('distinguishes an empty query value from a missing query', () => {
+    expect(
+      resolveServiceWorkerVersionForWorker(
+        'https://example.test/service-worker.js?vrowzer-version=',
+        undefined
+      )
+    ).toBe('')
+  })
+
+  test('ignores unrelated query parameters', () => {
+    expect(
+      resolveServiceWorkerVersionForWorker(
+        'https://example.test/service-worker.js?sw=service_worker_file',
+        undefined
+      )
+    ).toBe(DEFAULT_SERVICE_WORKER_VERSION)
+  })
+
+  test.each(['', ' app v2 ', 'version/β+二'])(
+    'accepts a URL object and preserves opaque value %j',
+    version => {
+      const scriptURL = withServiceWorkerVersion(
+        new URL('https://example.test/service-worker.js?sw=service_worker_file'),
+        version
+      )
+
+      expect(resolveServiceWorkerVersionForWorker(scriptURL, undefined)).toBe(version)
+      expect(resolveServiceWorkerVersionForWorker(scriptURL, version)).toBe(version)
+      expect(
+        resolveServiceWorkerVersionForWorker('https://example.test/service-worker.js', version)
+      ).toBe(version)
+    }
+  )
+})

--- a/packages/vrowzer/src/service-worker-version.ts
+++ b/packages/vrowzer/src/service-worker-version.ts
@@ -1,0 +1,60 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+export const DEFAULT_SERVICE_WORKER_VERSION = 'vrowzer-v1'
+export const VROWZER_SERVICE_WORKER_VERSION_QUERY = 'vrowzer-version'
+
+declare const __VROWZER_INTERNAL_SERVICE_WORKER_VERSION__: string
+
+function getInjectedServiceWorkerVersion(): string | undefined {
+  return typeof __VROWZER_INTERNAL_SERVICE_WORKER_VERSION__ === 'string'
+    ? __VROWZER_INTERNAL_SERVICE_WORKER_VERSION__
+    : undefined
+}
+
+export function resolveServiceWorkerVersion(
+  runtimeVersion?: string,
+  injectedVersion: string | undefined = getInjectedServiceWorkerVersion()
+): string {
+  if (
+    runtimeVersion !== undefined &&
+    injectedVersion !== undefined &&
+    runtimeVersion !== injectedVersion
+  ) {
+    throw new Error(
+      `Vrowzer serviceWorkerVersion ${JSON.stringify(runtimeVersion)} does not match @vrowzer/vite-plugin serviceWorkerVersion ${JSON.stringify(injectedVersion)}. Configure serviceWorkerVersion in vite.config.ts.`
+    )
+  }
+
+  return injectedVersion ?? runtimeVersion ?? DEFAULT_SERVICE_WORKER_VERSION
+}
+
+export function withServiceWorkerVersion(scriptURL: URL, version: string): URL {
+  const versionedScriptURL = new URL(scriptURL.href)
+  versionedScriptURL.searchParams.set(VROWZER_SERVICE_WORKER_VERSION_QUERY, version)
+  return versionedScriptURL
+}
+
+export function resolveServiceWorkerVersionForWorker(
+  scriptURL: string | URL,
+  injectedVersion: string | undefined = getInjectedServiceWorkerVersion()
+): string {
+  const url = typeof scriptURL === 'string' ? new URL(scriptURL) : scriptURL
+  const queryVersion = url.searchParams.has(VROWZER_SERVICE_WORKER_VERSION_QUERY)
+    ? (url.searchParams.get(VROWZER_SERVICE_WORKER_VERSION_QUERY) ?? '')
+    : undefined
+
+  if (
+    injectedVersion !== undefined &&
+    queryVersion !== undefined &&
+    injectedVersion !== queryVersion
+  ) {
+    throw new Error(
+      `Vrowzer injected serviceWorkerVersion ${JSON.stringify(injectedVersion)} does not match Service Worker script URL version ${JSON.stringify(queryVersion)}.`
+    )
+  }
+
+  return injectedVersion ?? queryVersion ?? DEFAULT_SERVICE_WORKER_VERSION
+}

--- a/packages/vrowzer/vite.config.ts
+++ b/packages/vrowzer/vite.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
           cpSync(resolve(srcDir, 'service-worker.ts'), resolve(distDir, 'service-worker.ts'))
           cpSync(resolve(srcDir, 'preview-base.ts'), resolve(distDir, 'preview-base.ts'))
           cpSync(
+            resolve(srcDir, 'service-worker-version.ts'),
+            resolve(distDir, 'service-worker-version.ts')
+          )
+          cpSync(
             resolve(srcDir, 'service-worker-core.ts'),
             resolve(distDir, 'service-worker-core.ts')
           )


### PR DESCRIPTION
## Summary

Use the Vite plugin `serviceWorkerVersion` as the source of truth for both the page runtime and Service Worker. The resolved value is injected at build time and appended to the worker script URL, while plugin-free builds retain the runtime option and `vrowzer-v1` fallback.

Explicit version mismatches now fail before registration. Unit and dev/build integration tests cover default and custom values, URL query preservation, opaque versions, worker responses, reload behavior, and packaged output.

Closes #20.