### PR TITLE
fix(unplugin): handle versioned service worker entry URLs

### DIFF
--- a/packages/unplugin-service-worker/src/core/entry-url.ts
+++ b/packages/unplugin-service-worker/src/core/entry-url.ts
@@ -18,6 +18,14 @@ function safeRealpath(filePath: string): string {
   }
 }
 
+function isPathInsideRoot(filePath: string, root: string): boolean {
+  const relative = path.relative(root, filePath)
+  return (
+    relative === '' ||
+    (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  )
+}
+
 export function stripViteBase(pathname: string, base: string): string {
   const basePath = new URL(base, 'http://localhost').pathname
   if (basePath === '/') {
@@ -44,7 +52,8 @@ export function rewriteEntryUrls(
   mode: 'placeholder' | 'rollup' | 'dev',
   emitFile?: (file: { type: 'chunk'; id: string; name: string }) => string,
   rollupReferenceIds?: Map<string, string>,
-  isTest = false
+  isTest = false,
+  useViteAssetTransform = false
 ): { code: string; map: ReturnType<MagicString['generateMap']> } | null {
   const urlPatternRE =
     /new\s+URL\s*\(\s*(['"`])([^'"`]+)\1\s*,\s*(?:['"`]\s*\+\s*)?import\.meta\.url\s*\)/g
@@ -93,11 +102,25 @@ export function rewriteEntryUrls(
         )
       } else {
         const devUrl = injectDevQuery(urlPath)
-        const baseUrl = isTest ? 'self.location.href' : "'' + import.meta.url"
+        // An optimized workspace dependency can be served from the project-root
+        // /node_modules path while its entry resolves outside that root. Let Vite
+        // convert this URL to /@fs/ so browser-relative traversal does not lose
+        // the filesystem prefix.
+        const deferToVite =
+          !isTest &&
+          useViteAssetTransform &&
+          isPathInsideRoot(id.replace(/[?#].*$/, ''), root) &&
+          !isPathInsideRoot(resolvedPath, root)
+        const viteIgnore = deferToVite ? '' : '/* @vite-ignore */ '
+        const baseUrl = isTest
+          ? 'self.location.href'
+          : deferToVite
+            ? 'import.meta.url'
+            : "'' + import.meta.url"
         s.update(
           urlMatch.index,
           urlMatch.index + urlMatch[0].length,
-          `new URL(/* @vite-ignore */ ${JSON.stringify(devUrl)}, ${baseUrl})`
+          `new URL(${viteIgnore}${JSON.stringify(devUrl)}, ${baseUrl})`
         )
       }
       hasReplacement = true

--- a/packages/unplugin-service-worker/src/core/options.test.ts
+++ b/packages/unplugin-service-worker/src/core/options.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { resolveOptions } from './options.ts'
+import { resolveOptions, SCRIPT_MODULE_ID_RE } from './options.ts'
 
 import type { Plugin } from 'rolldown'
 
@@ -7,7 +7,7 @@ describe('resolveOptions', () => {
   it('should set default values when no options provided', () => {
     const resolved = resolveOptions({})
 
-    expect(resolved.include).toEqual([/\.[cm]?[jt]sx?$/, /\.vue$/, /\.svelte$/])
+    expect(resolved.include).toEqual([SCRIPT_MODULE_ID_RE, /\.vue(?:$|[?#])/, /\.svelte(?:$|[?#])/])
     expect(resolved.exclude).toEqual([/node_modules/])
     expect(resolved.enforce).toBe('pre')
     expect(resolved.serviceWorkerAllowed).toBeUndefined()
@@ -65,5 +65,45 @@ describe('resolveOptions', () => {
   it('should leave assets undefined when not specified', () => {
     const resolved = resolveOptions({})
     expect(resolved.assets).toBeUndefined()
+  })
+
+  it('should preserve a custom include filter', () => {
+    const include = [/\.custom$/]
+
+    expect(resolveOptions({ include }).include).toBe(include)
+  })
+})
+
+describe('SCRIPT_MODULE_ID_RE', () => {
+  it.each([
+    '/src/index.js',
+    '/src/index.jsx',
+    '/src/index.ts',
+    '/src/index.tsx',
+    '/src/index.mjs',
+    '/src/index.mts',
+    '/src/index.cjs',
+    '/src/index.cts',
+    '/src/index.js?v=abc123',
+    '/src/index.ts?raw',
+    '/src/index.mjs#fragment'
+  ])('should match script module ID %s', id => {
+    expect(SCRIPT_MODULE_ID_RE.test(id)).toBe(true)
+  })
+
+  it.each([
+    '/src/styles.css?v=abc123',
+    '/src/module.wasm?url',
+    '/src/data.json#fragment',
+    '/src/extensionless'
+  ])('should not match non-script module ID %s', id => {
+    expect(SCRIPT_MODULE_ID_RE.test(id)).toBe(false)
+  })
+
+  it('should match query and hash suffixes in the default SFC filters', () => {
+    const includes = resolveOptions({}).include as RegExp[]
+
+    expect(includes.some(include => include.test('/src/App.vue?vue&type=script'))).toBe(true)
+    expect(includes.some(include => include.test('/src/App.svelte?v=abc123'))).toBe(true)
   })
 })

--- a/packages/unplugin-service-worker/src/core/options.ts
+++ b/packages/unplugin-service-worker/src/core/options.ts
@@ -5,6 +5,8 @@
 
 import type { FilterPattern } from 'unplugin'
 
+export const SCRIPT_MODULE_ID_RE = /\.[cm]?[jt]sx?(?:$|[?#])/
+
 /**
  * Options for the Service Worker plugin.
  */
@@ -26,7 +28,7 @@ export interface Options {
   /**
    * Files to include for Service Worker processing.
    *
-   * @default [/\.[cm]?[jt]sx?$/, /\.vue$/, /\.svelte$/]
+   * @default [/\.[cm]?[jt]sx?(?:$|[?#])/, /\.vue(?:$|[?#])/, /\.svelte(?:$|[?#])/]
    */
   include?: FilterPattern
   /**
@@ -110,7 +112,7 @@ export function resolveOptions(options: Options): OptionsResolved {
   return {
     entry: options.entry,
     // Include JS/TS files and Vue/Svelte SFC files by default
-    include: options.include || [/\.[cm]?[jt]sx?$/, /\.vue$/, /\.svelte$/],
+    include: options.include || [SCRIPT_MODULE_ID_RE, /\.vue(?:$|[?#])/, /\.svelte(?:$|[?#])/],
     exclude: options.exclude || [/node_modules/],
     enforce: 'enforce' in options ? options.enforce : 'pre',
     serviceWorkerAllowed: options.serviceWorkerAllowed,

--- a/packages/unplugin-service-worker/src/core/plugin-utils.test.ts
+++ b/packages/unplugin-service-worker/src/core/plugin-utils.test.ts
@@ -20,6 +20,59 @@ describe('rewriteEntryUrls', () => {
     expect(result?.code).toContain("'' + import.meta.url")
   })
 
+  it('should route an explicit entry when the importer has a Vite cache query', () => {
+    const result = rewriteEntryUrls(code, `${id}?v=abc123`, entry, '/project', 'dev')
+
+    expect(result?.code).toContain('./service-worker.ts?sw=service_worker_file')
+    expect(result?.code).toContain('/* @vite-ignore */')
+  })
+
+  it('should let Vite normalize an optimized workspace entry outside the project root', () => {
+    const root = '/project/apps/host'
+    const optimizedId = `${root}/node_modules/.vite/deps/vrowzer.js?v=abc123`
+    const workspaceEntry = '/project/packages/vrowzer/dist/service-worker.ts'
+    const optimizedCode = `const scriptURL = new URL('../../../../../packages/vrowzer/dist/service-worker.ts', import.meta.url)`
+    const result = rewriteEntryUrls(
+      optimizedCode,
+      optimizedId,
+      workspaceEntry,
+      root,
+      'dev',
+      undefined,
+      undefined,
+      false,
+      true
+    )
+
+    expect(result?.code).toContain(
+      `new URL("../../../../../packages/vrowzer/dist/service-worker.ts?sw=service_worker_file", import.meta.url)`
+    )
+    expect(result?.code).not.toContain('@vite-ignore')
+  })
+
+  it('should preserve the optimized npm entry URL when the importer is outside the Vite root', () => {
+    const root = '/project/host'
+    const optimizedId = '/project/node_modules/.vite/deps/vrowzer.js?v=abc123'
+    const npmEntry =
+      '/project/node_modules/.pnpm/vrowzer@0.1.2/node_modules/vrowzer/dist/service-worker.ts'
+    const optimizedCode = `const scriptURL = new URL('../../.pnpm/vrowzer@0.1.2/node_modules/vrowzer/dist/service-worker.ts', import.meta.url)`
+    const result = rewriteEntryUrls(
+      optimizedCode,
+      optimizedId,
+      npmEntry,
+      root,
+      'dev',
+      undefined,
+      undefined,
+      false,
+      true
+    )
+
+    expect(result?.code).toContain(
+      `new URL(/* @vite-ignore */ "../../.pnpm/vrowzer@0.1.2/node_modules/vrowzer/dist/service-worker.ts?sw=service_worker_file", '' + import.meta.url)`
+    )
+  })
+
   it('should preserve placeholder rewriting in build mode', () => {
     const result = rewriteEntryUrls(code, id, entry, '/project', 'placeholder')
 

--- a/packages/unplugin-service-worker/src/core/vite-query.test.ts
+++ b/packages/unplugin-service-worker/src/core/vite-query.test.ts
@@ -50,6 +50,17 @@ describe('createViteQueryPlugin', () => {
       expect(result!.code).toContain('createViteQueryPlugin')
     })
 
+    it('should strip a Vite cache query before reading a file for ?raw', async () => {
+      const plugin = createViteQueryPlugin()
+      const load = plugin.load as { handler: (id: string) => Promise<{ code: string } | null> }
+
+      const testFile = path.resolve(__dirname, 'vite-query.test.ts')
+      const result = await load.handler.call({}, `${testFile}?v=abc123&raw`)
+
+      expect(result).not.toBeNull()
+      expect(result!.code).toContain('createViteQueryPlugin')
+    })
+
     it('should return null for non-existent file', async () => {
       const plugin = createViteQueryPlugin()
       const load = plugin.load as { handler: (id: string) => Promise<{ code: string } | null> }

--- a/packages/unplugin-service-worker/src/index.ts
+++ b/packages/unplugin-service-worker/src/index.ts
@@ -18,7 +18,7 @@ import {
 import { rewriteEntryUrls, stripViteBase } from './core/entry-url.ts'
 import { injectEnvironmentToHooks, resolvePluginsForEnvironment } from './core/environment-hooks.ts'
 import { hash } from './core/hash.ts'
-import { resolveOptions } from './core/options.ts'
+import { resolveOptions, SCRIPT_MODULE_ID_RE } from './core/options.ts'
 import { injectDevQuery } from './transform/dev.ts'
 import { detectAndResolveServiceWorkers, needsTransform } from './transform/utils.ts'
 
@@ -1002,7 +1002,7 @@ function createViteConfigureServer(ctx: PluginContext, options: OptionsResolved)
         ssr: false
       })
       if (resolved) {
-        filePath = resolved.id
+        filePath = cleanUrl(resolved.id)
       }
 
       // Strategy 2: Try resolving relative to project root (for test mode)
@@ -1605,6 +1605,7 @@ export const ServiceWorkerPlugin: UnpluginInstance<Options | undefined, false> =
     const name = 'unplugin-service-worker'
 
     // Check framework type
+    const isVite = meta.framework === 'vite'
     const isRollup = meta.framework === 'rollup'
     const isRolldown = meta.framework === 'rolldown'
     const isRollupLike = isRollup || isRolldown
@@ -1658,7 +1659,7 @@ export const ServiceWorkerPlugin: UnpluginInstance<Options | undefined, false> =
                   // to the entry file. This allows rewriting URLs in library code (e.g. vrowzer).
                   id: {
                     include: [
-                      /\.[cm]?[jt]sx?$/,
+                      SCRIPT_MODULE_ID_RE,
                       ...((Array.isArray(options.include)
                         ? options.include
                         : options.include
@@ -1688,7 +1689,8 @@ export const ServiceWorkerPlugin: UnpluginInstance<Options | undefined, false> =
                   ctx.isBuild ? 'placeholder' : 'dev',
                   undefined,
                   undefined,
-                  ctx.isTest
+                  ctx.isTest,
+                  isVite
                 )
                 if (result) {
                   return result
@@ -1768,7 +1770,7 @@ export const ServiceWorkerPlugin: UnpluginInstance<Options | undefined, false> =
         },
         transform: {
           filter: options.entry
-            ? { id: /\.[cm]?[jt]sx?$/, code: /new\s+URL\s*\(/ }
+            ? { id: SCRIPT_MODULE_ID_RE, code: /new\s+URL\s*\(/ }
             : { id: options.include, code: SW_CONTROLLER_FILTER_RE },
           handler(code, id) {
             // When entry is specified, rewrite new URL() references (including in node_modules)
@@ -1825,7 +1827,7 @@ export const ServiceWorkerPlugin: UnpluginInstance<Options | undefined, false> =
         },
         transform: {
           filter: options.entry
-            ? { id: /\.[cm]?[jt]sx?$/, code: /new\s+URL\s*\(/ }
+            ? { id: SCRIPT_MODULE_ID_RE, code: /new\s+URL\s*\(/ }
             : { id: options.include, code: SW_CONTROLLER_FILTER_RE },
           handler(code: string, id: string) {
             // When entry is specified, rewrite new URL() references (including in node_modules)


### PR DESCRIPTION
Fixes #14.

Vite can append cache queries such as `?v=<hash>` to optimized module IDs. The service worker plugin previously skipped those IDs and could pass a queried resolver result to Rolldown, causing the worker entry to be served as an unbundled module.

This change accepts query/hash-suffixed script IDs, strips Vite queries before bundling, and lets Vite normalize workspace entries outside the project root to `/@fs/`.

Unit, integration, official Vite 8.1.5, development E2E, build E2E, and repository-wide checks pass.