### PR TITLE
fix(vrowzer): make service worker ready timeout configurable

### DIFF
--- a/packages/vrowzer/README.md
+++ b/packages/vrowzer/README.md
@@ -125,13 +125,22 @@ const vrowzer = Vrowzer()
 
 The runtime `serviceWorkerVersion` remains available for compatibility and for builds without the plugin. If both values are provided, they must match or `Vrowzer()` throws before registration. Without either value, the version defaults to `vrowzer-v1`. The resolved version is also reflected in the Service Worker script URL, so changing it may trigger a Service Worker update.
 
+`serviceWorkerReadyTimeout` controls how long the runtime waits for the Service Worker to become the page controller. It defaults to 60000 milliseconds and can be extended for large bundles or slow environments:
+
+```ts
+const vrowzer = Vrowzer({ serviceWorkerReadyTimeout: 120000 })
+```
+
+This timeout does not apply to Service Worker listen readiness or Web Worker setup, and it does not need a corresponding Vite plugin option.
+
 **Options:**
 
-| Option                 | Type     | Default                           | Description                                            |
-| ---------------------- | -------- | --------------------------------- | ------------------------------------------------------ |
-| `basePath`             | `string` | Plugin value or `'/__preview__/'` | Preview URL pathname; must match the plugin value       |
-| `serviceWorkerVersion` | `string` | Plugin value or `'vrowzer-v1'`    | SW version; must match the plugin value                 |
-| `serviceWorkerScope`   | `string` | Plugin value or `'/'`             | SW registration scope; must match the plugin value      |
+| Option                      | Type     | Default                           | Description                                                  |
+| --------------------------- | -------- | --------------------------------- | ------------------------------------------------------------ |
+| `basePath`                  | `string` | Plugin value or `'/__preview__/'` | Preview URL pathname; must match the plugin value             |
+| `serviceWorkerVersion`      | `string` | Plugin value or `'vrowzer-v1'`    | SW version; must match the plugin value                       |
+| `serviceWorkerScope`        | `string` | Plugin value or `'/'`             | SW registration scope; must match the plugin value            |
+| `serviceWorkerReadyTimeout` | `number` | `60000`                           | Milliseconds to wait for the Service Worker page controller   |
 
 ### Instance Methods
 

--- a/packages/vrowzer/docs/default/interfaces/VrowzerOptions.md
+++ b/packages/vrowzer/docs/default/interfaces/VrowzerOptions.md
@@ -13,5 +13,6 @@ export interface VrowzerOptions
 | Name | Type | Description |
 | --- | --- | --- |
 | `basePath` _(optional)_ | `string` | Preview URL pathname. When `@vrowzer/vite-plugin` is used, its `basePath` is injected and this option can be omitted. If both are provided, their canonical values must match. Without the plugin, this option defaults to `'/__preview__/'`. |
+| `serviceWorkerReadyTimeout` _(optional)_ | `number` | Timeout in milliseconds for the Service Worker to become the page controller. This timeout does not apply to Service Worker listen readiness or Web Worker setup. **Default:** `60000` |
 | `serviceWorkerScope` _(optional)_ | `string` | Service Worker registration scope, independent of `basePath`. When `@vrowzer/vite-plugin` is used, its `serviceWorkerScope` is injected and this option can be omitted. If both are provided, their values must match. Without the plugin, this option defaults to `'/'`. |
 | `serviceWorkerVersion` _(optional)_ | `string` | Service Worker version for cache management. When `@vrowzer/vite-plugin` is used, its `serviceWorkerVersion` is injected and this option can be omitted. If both are provided, their values must match. Without the plugin, this option defaults to `'vrowzer-v1'`. |

--- a/packages/vrowzer/integration/playground/main.ts
+++ b/packages/vrowzer/integration/playground/main.ts
@@ -2,9 +2,17 @@ import { Vrowzer } from 'vrowzer'
 
 const status = document.getElementById('status')!
 const container = document.getElementById('preview-container')!
+const serviceWorkerReadyTimeout = new URLSearchParams(location.search).get(
+  'serviceWorkerReadyTimeout'
+)
 
 // Expose vrowzer instance for E2E test access
-const vrowzer = Vrowzer({ basePath: '/__preview__/' })
+const vrowzer = Vrowzer({
+  basePath: '/__preview__/',
+  ...(serviceWorkerReadyTimeout === null
+    ? {}
+    : { serviceWorkerReadyTimeout: Number(serviceWorkerReadyTimeout) })
+})
 ;(window as any).__vrowzer__ = vrowzer
 
 async function init() {

--- a/packages/vrowzer/integration/vrowzer.integration-test.ts
+++ b/packages/vrowzer/integration/vrowzer.integration-test.ts
@@ -13,19 +13,40 @@ import { build, preview } from 'vite'
 import { afterAll, beforeAll, describe, expect, test } from 'vite-plus/test'
 
 import type { Browser, Page } from '@playwright/test'
-import type { PreviewServer } from 'vite'
+import type { Plugin, PreviewServer } from 'vite'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PLAYGROUND_DIR = join(__dirname, 'playground')
 
 const E2E_DEBUG = process.env.E2E_DEBUG === '1' || process.env.E2E_DEBUG === 'true'
 const debug = (...args: unknown[]) => E2E_DEBUG && console.log('[E2E]', ...args)
+const SERVICE_WORKER_RESPONSE_DELAY = Number(process.env.VROWZER_TEST_SW_RESPONSE_DELAY ?? 0)
+const CUSTOM_SERVICE_WORKER_READY_TIMEOUT = process.env.VROWZER_TEST_SW_READY_TIMEOUT
+  ? Number(process.env.VROWZER_TEST_SW_READY_TIMEOUT)
+  : undefined
 
 let browser: Browser
 let server: PreviewServer
 let page: Page
 let serverUrl: string
 let pageConsoleLogs: string[] = []
+let delayedServiceWorkerRequests = 0
+
+function delayServiceWorkerResponse(delay: number): Plugin {
+  return {
+    name: 'vrowzer:test-delay-service-worker-response',
+    configurePreviewServer(server) {
+      server.middlewares.use((request, _response, next) => {
+        if (!request.url?.startsWith('/assets/service-worker-')) {
+          next()
+          return
+        }
+        delayedServiceWorkerRequests++
+        setTimeout(next, delay)
+      })
+    }
+  }
+}
 
 interface PreviewResponse {
   status: number
@@ -129,6 +150,25 @@ function extractInlineSourceMap(code: string): SourceMapPayload {
 }
 
 beforeAll(async () => {
+  if (!Number.isFinite(SERVICE_WORKER_RESPONSE_DELAY) || SERVICE_WORKER_RESPONSE_DELAY < 0) {
+    throw new Error('VROWZER_TEST_SW_RESPONSE_DELAY must be a non-negative finite number')
+  }
+  if (
+    CUSTOM_SERVICE_WORKER_READY_TIMEOUT !== undefined &&
+    (!Number.isFinite(CUSTOM_SERVICE_WORKER_READY_TIMEOUT) ||
+      CUSTOM_SERVICE_WORKER_READY_TIMEOUT < 0)
+  ) {
+    throw new Error('VROWZER_TEST_SW_READY_TIMEOUT must be a non-negative finite number')
+  }
+  if (
+    CUSTOM_SERVICE_WORKER_READY_TIMEOUT !== undefined &&
+    SERVICE_WORKER_RESPONSE_DELAY <= CUSTOM_SERVICE_WORKER_READY_TIMEOUT
+  ) {
+    throw new Error(
+      'VROWZER_TEST_SW_RESPONSE_DELAY must be greater than VROWZER_TEST_SW_READY_TIMEOUT'
+    )
+  }
+
   debug('Building playground...')
   await build({
     root: PLAYGROUND_DIR,
@@ -138,6 +178,10 @@ beforeAll(async () => {
 
   server = await preview({
     root: PLAYGROUND_DIR,
+    plugins:
+      SERVICE_WORKER_RESPONSE_DELAY > 0
+        ? [delayServiceWorkerResponse(SERVICE_WORKER_RESPONSE_DELAY)]
+        : [],
     preview: {
       port: 0,
       strictPort: false,
@@ -175,6 +219,7 @@ beforeAll(async () => {
     debug(log)
   })
 
+  const initializationStartedAt = Date.now()
   await page.goto(serverUrl)
 
   // Wait for ready() to complete (status becomes "Ready" or error).
@@ -201,6 +246,16 @@ beforeAll(async () => {
   if (status !== 'Ready') {
     throw new Error(
       `Expected vrowzer playground to become Ready, got ${JSON.stringify(status)}\n${pageConsoleLogs.join('\n')}`
+    )
+  }
+
+  if (SERVICE_WORKER_RESPONSE_DELAY > 0) {
+    if (delayedServiceWorkerRequests === 0) {
+      throw new Error('The Service Worker response delay did not match a request')
+    }
+    console.log(
+      `[E2E] Service Worker response delayed by ${SERVICE_WORKER_RESPONSE_DELAY}ms; ` +
+        `Vrowzer became ready in ${Date.now() - initializationStartedAt}ms`
     )
   }
 }, 120000)
@@ -311,6 +366,35 @@ if (import.meta.hot) {
 
       expect(swState).toBe('activated')
     })
+
+    test.skipIf(CUSTOM_SERVICE_WORKER_READY_TIMEOUT === undefined)(
+      'applies a custom Service Worker ready timeout',
+      async () => {
+        const context = await browser.newContext()
+        const timeoutPage = await context.newPage()
+        const consoleLogs: string[] = []
+        timeoutPage.on('console', message => consoleLogs.push(message.text()))
+
+        try {
+          await timeoutPage.goto(
+            `${serverUrl}?serviceWorkerReadyTimeout=${CUSTOM_SERVICE_WORKER_READY_TIMEOUT}`
+          )
+          await timeoutPage.waitForFunction(
+            () => document.getElementById('status')?.textContent === 'Failed to initialize',
+            undefined,
+            { timeout: 10_000 }
+          )
+
+          expect(consoleLogs).toContainEqual(
+            expect.stringContaining(
+              `Service Worker controller did not become ready within ${CUSTOM_SERVICE_WORKER_READY_TIMEOUT}ms`
+            )
+          )
+        } finally {
+          await context.close()
+        }
+      }
+    )
   })
 
   describe('filesystem security', () => {

--- a/packages/vrowzer/src/controller-ready-timeout.test.ts
+++ b/packages/vrowzer/src/controller-ready-timeout.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, test, vi } from 'vite-plus/test'
+
+import type { SvcWorkerController } from '@vrowzer/service-worker/controller'
+
+type CreateSvcWorkerController =
+  (typeof import('@vrowzer/service-worker/controller'))['createSvcWorkerController']
+
+const createSvcWorkerControllerMock = vi.hoisted(() => vi.fn<CreateSvcWorkerController>())
+
+vi.mock('@vrowzer/service-worker/controller', () => ({
+  createSvcWorkerController: createSvcWorkerControllerMock
+}))
+
+import { initServiceWorker } from './controller.ts'
+
+const options = {
+  scriptURL: new URL('https://example.com/service-worker.js'),
+  version: 'test-version',
+  scope: '/',
+  readyTimeout: 1234
+}
+
+function mockReady(): ReturnType<typeof vi.fn<SvcWorkerController['ready']>> {
+  const ready = vi.fn<SvcWorkerController['ready']>()
+  createSvcWorkerControllerMock.mockReturnValue({ ready } as unknown as SvcWorkerController)
+  return ready
+}
+
+describe('initServiceWorker ready timeout', () => {
+  beforeEach(() => {
+    createSvcWorkerControllerMock.mockReset()
+  })
+
+  test('forwards the timeout and existing controller policies', async () => {
+    const ready = mockReady().mockResolvedValue(false)
+
+    await expect(initServiceWorker(options)).rejects.toThrow(
+      'Service Worker controller did not become ready within 1234ms'
+    )
+    expect(ready).toHaveBeenCalledTimes(1)
+    expect(ready).toHaveBeenCalledWith({
+      timeout: 1234,
+      skipWaitingPolicy: 'force',
+      waitForController: true
+    })
+  })
+
+  test('preserves errors thrown by the controller', async () => {
+    const failure = new Error('registration failed')
+    mockReady().mockRejectedValue(failure)
+
+    await expect(initServiceWorker(options)).rejects.toBe(failure)
+  })
+})

--- a/packages/vrowzer/src/controller.ts
+++ b/packages/vrowzer/src/controller.ts
@@ -46,6 +46,7 @@ export async function initServiceWorker(options: {
   scriptURL: URL
   version: string
   scope: string
+  readyTimeout: number
   listenReadyTimeout?: number
 }): Promise<SvcWorkerController> {
   controller = createSvcWorkerController({
@@ -56,12 +57,14 @@ export async function initServiceWorker(options: {
   })
 
   const ready = await controller.ready({
-    timeout: 10000,
+    timeout: options.readyTimeout,
     skipWaitingPolicy: 'force',
     waitForController: true
   })
   if (!ready) {
-    throw new Error('Service Worker failed to become ready')
+    throw new Error(
+      `Service Worker controller did not become ready within ${options.readyTimeout}ms`
+    )
   }
 
   // Wait for Service Worker's listen() to complete (listenConnections registered).

--- a/packages/vrowzer/src/index-ready-timeout.test.ts
+++ b/packages/vrowzer/src/index-ready-timeout.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vite-plus/test'
+import { V_WW_READY, V_WW_SETUP, V_WW_SETUP_ACK } from '@vrowzer/vite-dev-server/messages'
+
+const controllerMocks = vi.hoisted(() => ({
+  getController: vi.fn<() => null>(() => null),
+  getServiceWorker: vi.fn<() => null>(() => null),
+  initServiceWorker: vi.fn<() => Promise<undefined>>(async () => undefined)
+}))
+
+vi.mock('./controller.ts', () => controllerMocks)
+vi.mock('@vrowzer/vite-dev-server/dist/client/client.mjs?raw', () => ({ default: '' }))
+vi.mock('@vrowzer/vite-dev-server/dist/client/env.mjs?raw', () => ({ default: '' }))
+
+import { Vrowzer } from './index.ts'
+
+class TestWorker {
+  onerror: ((event: ErrorEvent) => void) | null = null
+  private messageHandler: ((event: MessageEvent) => void) | null = null
+  private readySent = false
+
+  get onmessage(): ((event: MessageEvent) => void) | null {
+    return this.messageHandler
+  }
+
+  set onmessage(handler: ((event: MessageEvent) => void) | null) {
+    this.messageHandler = handler
+    if (handler && !this.readySent) {
+      this.readySent = true
+      queueMicrotask(() => {
+        this.messageHandler?.({ data: { type: V_WW_READY } } as MessageEvent)
+      })
+    }
+  }
+
+  postMessage(message: unknown): void {
+    if (
+      typeof message === 'object' &&
+      message !== null &&
+      'type' in message &&
+      message.type === V_WW_SETUP
+    ) {
+      queueMicrotask(() => {
+        this.messageHandler?.({ data: { type: V_WW_SETUP_ACK } } as MessageEvent)
+      })
+    }
+  }
+}
+
+describe('Vrowzer Service Worker ready timeout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('Worker', TestWorker)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  test('uses 60000ms by default', async () => {
+    const vrowzer = Vrowzer()
+
+    await expect(vrowzer.ready({ files: {} })).resolves.toBe(true)
+    expect(controllerMocks.initServiceWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ readyTimeout: 60000 })
+    )
+  })
+
+  test('forwards a custom timeout', async () => {
+    const vrowzer = Vrowzer({ serviceWorkerReadyTimeout: 120000 })
+
+    await expect(vrowzer.ready({ files: {} })).resolves.toBe(true)
+    expect(controllerMocks.initServiceWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ readyTimeout: 120000 })
+    )
+  })
+
+  test('preserves zero as an explicit timeout', async () => {
+    const vrowzer = Vrowzer({ serviceWorkerReadyTimeout: 0 })
+
+    await expect(vrowzer.ready({ files: {} })).resolves.toBe(true)
+    expect(controllerMocks.initServiceWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ readyTimeout: 0 })
+    )
+  })
+
+  test('preserves the ready boolean contract when Service Worker initialization fails', async () => {
+    const failure = new Error('Service Worker controller did not become ready within 60000ms')
+    controllerMocks.initServiceWorker.mockRejectedValueOnce(failure)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const vrowzer = Vrowzer()
+
+    await expect(vrowzer.ready({ files: {} })).resolves.toBe(false)
+    expect(consoleError).toHaveBeenCalledWith('[Vrowzer] ready() failed:', failure)
+  })
+})

--- a/packages/vrowzer/src/index.ts
+++ b/packages/vrowzer/src/index.ts
@@ -61,6 +61,8 @@ import type { Emittable } from '@kazupon/jts-utils/event/emitter'
 import type { FileSystemPublisher } from '@vrowzer/fs/watcher'
 import type { SvcWorkerControllerEventMap } from '@vrowzer/service-worker/controller'
 
+const DEFAULT_SERVICE_WORKER_READY_TIMEOUT = 60_000
+
 /**
  * VrowzerOptions defines the configuration options for {@link Vrowzer}.
  */
@@ -89,6 +91,14 @@ export interface VrowzerOptions {
    * plugin, this option defaults to `'/'`.
    */
   serviceWorkerScope?: string
+  /**
+   * Timeout in milliseconds for the Service Worker to become the page controller.
+   *
+   * This timeout does not apply to Service Worker listen readiness or Web Worker setup.
+   *
+   * @default 60000
+   */
+  serviceWorkerReadyTimeout?: number
 }
 
 /**
@@ -158,13 +168,16 @@ interface ResolvedVrowzerOptions {
   basePath: string
   serviceWorkerVersion: string
   serviceWorkerScope: string
+  serviceWorkerReadyTimeout: number
 }
 
 function resolveVrowzerOptions(options: VrowzerOptions): ResolvedVrowzerOptions {
   return {
     basePath: resolvePreviewBasePath(options.basePath),
     serviceWorkerVersion: resolveServiceWorkerVersion(options.serviceWorkerVersion),
-    serviceWorkerScope: resolveServiceWorkerScope(options.serviceWorkerScope)
+    serviceWorkerScope: resolveServiceWorkerScope(options.serviceWorkerScope),
+    serviceWorkerReadyTimeout:
+      options.serviceWorkerReadyTimeout ?? DEFAULT_SERVICE_WORKER_READY_TIMEOUT
   }
 }
 
@@ -412,7 +425,8 @@ function execScript(orig, origin) {
               resolved.serviceWorkerVersion
             ),
             version: resolved.serviceWorkerVersion,
-            scope: resolved.serviceWorkerScope
+            scope: resolved.serviceWorkerScope,
+            readyTimeout: resolved.serviceWorkerReadyTimeout
           }),
           withTimeout(webWorkerReady(), 30000, 'Web Worker setup')
         ])


### PR DESCRIPTION
## Summary

Adds `serviceWorkerReadyTimeout` to `VrowzerOptions` with a 60-second default, replacing the fixed 10-second Service Worker controller deadline. Timeout errors now report the configured duration while `Vrowzer.ready()` keeps its boolean contract.

Adds unit and browser coverage for default, custom, zero, delayed cold-load, and error paths. Updates the README and generated API reference. Other worker timeouts and lower-level defaults remain unchanged.

## Validation

`vp run build`, `vp run check`, unit, integration, and development/build E2E tests passed.

Closes #16.