### PR TITLE
fix(vite-dev-server): bypass unowned service worker fetches

### DIFF
--- a/packages/vite-dev-server/src/node/service-worker.ts
+++ b/packages/vite-dev-server/src/node/service-worker.ts
@@ -17,12 +17,12 @@ import { createSvcWorkerServer } from '@vrowzer/service-worker-server'
 import { createBirpc } from 'birpc'
 import { Hono } from 'hono'
 import { handle } from 'hono/service-worker'
-import { isInternalRolldownAssetUrl } from '../shared/internalAssets'
 import {
   createServiceWorkerFunctions,
   deserializeRpcMessage,
   serializeRpcMessage,
 } from '../shared/rpc'
+import { shouldHandleViteFetch } from '../shared/serviceWorkerFetch'
 import { isResolvedConfig, resolveConfig } from './config'
 import { initPublicFiles } from './publicDir'
 import { baseMiddleware } from './server/middlewares/base'
@@ -332,6 +332,8 @@ export function createServer(
 ): () => Promise<ViteDevServerForServiceWorker> {
   const { server: serverConfig } = inlineConfig as InlineConfig | ResolvedConfig
   const middlewareMode = !!serverConfig?.middlewareMode
+  const basePath = options.basePath || '/'
+  const workerOrigin = new URL(serviceWorkerScope.location.href).origin
 
   let middlewares = new Hono<ViteEnv, BlankSchema, '/'>()
   const httpServer = createSvcWorkerServer<ConnectWebWorkerPortMessage | ViteMessageChannelInitMessage>(serviceWorkerScope, {
@@ -341,9 +343,9 @@ export function createServer(
   })
   const honoFetchHandler = handle(middlewares)
   const fetchHandler = (event: FetchEvent) => {
-    // These package assets belong to the host build, not the virtual project.
-    // Leaving the event unanswered makes the browser perform a network fetch.
-    if (isInternalRolldownAssetUrl(event.request.url)) {
+    // Leave requests outside the virtual project unanswered so the browser
+    // performs the fetch with the controlled client's native semantics.
+    if (!shouldHandleViteFetch(event.request.url, workerOrigin, basePath)) {
       return
     }
     honoFetchHandler(event)
@@ -373,7 +375,6 @@ export function createServer(
     const initPublicFilesPromise = initPublicFiles(config)
 
     const { root, server: serverConfig } = config
-    const basePath = options.basePath || '/'
 
     // Setup base path for hono middlewares
     if (basePath !== '/') {

--- a/packages/vite-dev-server/src/shared/serviceWorkerFetch.test.ts
+++ b/packages/vite-dev-server/src/shared/serviceWorkerFetch.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { shouldHandleViteFetch } from './serviceWorkerFetch'
+
+const WORKER_ORIGIN = 'https://host.example'
+const PREVIEW_BASE = '/__preview__/'
+
+describe('shouldHandleViteFetch', () => {
+  it.each([
+    ['preview root without a trailing slash', 'https://host.example/__preview__'],
+    ['preview root with a trailing slash', 'https://host.example/__preview__/'],
+    ['preview HTML', 'https://host.example/__preview__/index.html'],
+    ['preview JavaScript', 'https://host.example/__preview__/src/main.ts'],
+    ['preview CSS', 'https://host.example/__preview__/src/main.css'],
+    ['preview image', 'https://host.example/__preview__/public/logo.png'],
+    [
+      'preview URL with a query and hash',
+      'https://host.example/__preview__/main.ts?import&v=1#fragment'
+    ],
+    [
+      'unmarked asset with an internal asset file name',
+      'https://host.example/__preview__/rolldown-worker.js'
+    ]
+  ])('handles same-origin %s', (_name, rawUrl) => {
+    expect(shouldHandleViteFetch(rawUrl, WORKER_ORIGIN, PREVIEW_BASE)).toBe(true)
+  })
+
+  it.each([
+    ['a path outside basePath', 'https://host.example/api/data'],
+    ['a lookalike basePath', 'https://host.example/__preview__-other/main.ts'],
+    ['a normalized parent path', 'https://host.example/__preview__/../api/data'],
+    ['a different hostname', 'https://cdn.example/__preview__/logo.png'],
+    ['a different port', 'https://host.example:8443/__preview__/main.ts'],
+    ['a different scheme', 'http://host.example/__preview__/main.ts'],
+    ['a blob URL', 'blob:https://host.example/2daee084-cf6b-4eb0-b40f-fc7c630780a2'],
+    ['a data URL', 'data:text/plain,hello'],
+    ['an extension URL', 'chrome-extension://abcdefghijklmnop/index.js'],
+    [
+      'the marked internal Rolldown worker',
+      'https://host.example/__preview__/rolldown-worker.js?__vrowzer_internal_asset=rolldown'
+    ],
+    [
+      'the marked internal Rolldown WASM',
+      'https://host.example/__preview__/rolldown-binding.wasm32-wasi.wasm?__vrowzer_internal_asset=rolldown'
+    ]
+  ])('bypasses %s', (_name, rawUrl) => {
+    expect(shouldHandleViteFetch(rawUrl, WORKER_ORIGIN, PREVIEW_BASE)).toBe(false)
+  })
+
+  it.each([
+    ['the preview root', 'https://host.example/__preview__'],
+    ['a preview descendant', 'https://host.example/__preview__/nested/main.ts']
+  ])('supports a basePath without a trailing slash for %s', (_name, rawUrl) => {
+    expect(shouldHandleViteFetch(rawUrl, WORKER_ORIGIN, '/__preview__')).toBe(true)
+  })
+
+  it('handles same-origin HTTP requests', () => {
+    expect(
+      shouldHandleViteFetch(
+        'http://host.example/__preview__/src/main.ts',
+        'http://host.example',
+        PREVIEW_BASE
+      )
+    ).toBe(true)
+  })
+
+  it('handles regular same-origin requests when basePath is the origin root', () => {
+    expect(
+      shouldHandleViteFetch('https://host.example/src/main.ts', WORKER_ORIGIN, '/')
+    ).toBe(true)
+  })
+
+  it('still bypasses internal assets when basePath is the origin root', () => {
+    expect(
+      shouldHandleViteFetch(
+        'https://host.example/assets/rolldown-worker.js?__vrowzer_internal_asset=rolldown',
+        WORKER_ORIGIN,
+        '/'
+      )
+    ).toBe(false)
+  })
+
+  it('bypasses an invalid URL without throwing', () => {
+    expect(shouldHandleViteFetch('not a URL', WORKER_ORIGIN, PREVIEW_BASE)).toBe(false)
+  })
+})

--- a/packages/vite-dev-server/src/shared/serviceWorkerFetch.ts
+++ b/packages/vite-dev-server/src/shared/serviceWorkerFetch.ts
@@ -1,0 +1,34 @@
+import { isInternalRolldownAssetUrl } from './internalAssets'
+
+function isWithinBasePath(pathname: string, basePath: string): boolean {
+  if (basePath === '/') {
+    return true
+  }
+
+  const baseRoot = basePath.replace(/\/+$/, '')
+  if (!baseRoot.startsWith('/')) {
+    return false
+  }
+
+  return pathname === baseRoot || pathname.startsWith(`${baseRoot}/`)
+}
+
+export function shouldHandleViteFetch(
+  rawUrl: string,
+  workerOrigin: string,
+  basePath: string
+): boolean {
+  try {
+    const url = new URL(rawUrl)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return false
+    }
+    if (url.origin !== workerOrigin || !isWithinBasePath(url.pathname, basePath)) {
+      return false
+    }
+
+    return !isInternalRolldownAssetUrl(url.href)
+  } catch {
+    return false
+  }
+}

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -94,6 +94,8 @@ const vrowzer = Vrowzer()
 
 The runtime `Vrowzer({ serviceWorkerScope })` option remains available for compatibility and for builds without the plugin. If both values are provided, they must match or `Vrowzer()` throws before registration. Without either value, the scope and response header default to `/`.
 
+The scope selects which pages the Service Worker controls, not which request URLs it receives from those pages. Vrowzer only responds to same-origin HTTP(S) requests within `basePath`. Cross-origin requests and same-origin requests outside `basePath` are left to the browser's native network path.
+
 ### Service Worker version
 
 The plugin's `serviceWorkerVersion` is the source of truth for the version expected by the application and reported by the Service Worker. Configure it once in `vite.config.ts`; application code can call `Vrowzer()` without repeating the value:

--- a/packages/vrowzer/README.md
+++ b/packages/vrowzer/README.md
@@ -113,6 +113,8 @@ const vrowzer = Vrowzer()
 
 The runtime `serviceWorkerScope` remains available for compatibility and for builds without the plugin. If both values are provided, they must match or `Vrowzer()` throws before registration. Without either value, the scope defaults to `/`. The scope does not set the preview URL; that is the role of `basePath`.
 
+The scope selects which pages the Service Worker controls, not which request URLs it receives from those pages. Vrowzer only responds to same-origin HTTP(S) requests within `basePath`. Cross-origin requests and same-origin requests outside `basePath` are left to the browser's native network path.
+
 `serviceWorkerVersion` identifies the Service Worker version expected by the controller and reported by the worker. When `@vrowzer/vite-plugin` is used, configure the version on the plugin and omit the runtime option:
 
 ```ts

--- a/packages/vrowzer/integration/vrowzer.integration-test.ts
+++ b/packages/vrowzer/integration/vrowzer.integration-test.ts
@@ -7,12 +7,14 @@
  */
 
 import { chromium } from '@playwright/test'
+import { createServer as createHttpServer } from 'node:http'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { build, preview } from 'vite'
 import { afterAll, beforeAll, describe, expect, test } from 'vite-plus/test'
 
-import type { Browser, Page } from '@playwright/test'
+import type { Browser, Page, Response as PlaywrightResponse } from '@playwright/test'
+import type { Server as HttpServer } from 'node:http'
 import type { Plugin, PreviewServer } from 'vite'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -24,11 +26,18 @@ const SERVICE_WORKER_RESPONSE_DELAY = Number(process.env.VROWZER_TEST_SW_RESPONS
 const CUSTOM_SERVICE_WORKER_READY_TIMEOUT = process.env.VROWZER_TEST_SW_READY_TIMEOUT
   ? Number(process.env.VROWZER_TEST_SW_READY_TIMEOUT)
   : undefined
+const HOST_FETCH_PROBE_PATH = '/vrowzer-host-fetch-probe.txt'
+const CROSS_ORIGIN_PIXEL = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+  'base64'
+)
 
 let browser: Browser
 let server: PreviewServer
+let crossOriginAssetServer: HttpServer
 let page: Page
 let serverUrl: string
+let crossOriginAssetServerUrl: string
 let pageConsoleLogs: string[] = []
 let delayedServiceWorkerRequests = 0
 
@@ -45,6 +54,62 @@ function delayServiceWorkerResponse(delay: number): Plugin {
         setTimeout(next, delay)
       })
     }
+  }
+}
+
+function serveHostFetchProbe(): Plugin {
+  return {
+    name: 'vrowzer:test-host-fetch-probe',
+    configurePreviewServer(server) {
+      server.middlewares.use((request, response, next) => {
+        const pathname = new URL(request.url ?? '/', 'http://localhost').pathname
+        if (pathname !== HOST_FETCH_PROBE_PATH) {
+          next()
+          return
+        }
+
+        response.statusCode = 200
+        response.setHeader('Content-Type', 'text/plain; charset=utf-8')
+        response.setHeader('Cache-Control', 'no-store')
+        response.end('host-owned')
+      })
+    }
+  }
+}
+
+async function closeHttpServer(server: HttpServer | undefined): Promise<void> {
+  if (!server?.listening) {
+    return
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+async function captureResponse<T>(
+  requestUrl: string,
+  operation: () => Promise<T>
+): Promise<{ result: T; response: PlaywrightResponse | undefined }> {
+  let matchingResponse: PlaywrightResponse | undefined
+  const onResponse = (response: PlaywrightResponse) => {
+    if (response.url() === requestUrl) {
+      matchingResponse = response
+    }
+  }
+
+  page.on('response', onResponse)
+  try {
+    const result = await operation()
+    return { result, response: matchingResponse }
+  } finally {
+    page.off('response', onResponse)
   }
 }
 
@@ -176,12 +241,39 @@ beforeAll(async () => {
   })
   debug('Build complete')
 
+  crossOriginAssetServer = createHttpServer((request, response) => {
+    const pathname = new URL(request.url ?? '/', 'http://127.0.0.1').pathname
+    if (pathname !== '/pixel.png') {
+      response.writeHead(404)
+      response.end('Not Found')
+      return
+    }
+
+    response.statusCode = 200
+    response.setHeader('Content-Type', 'image/png')
+    response.setHeader('Content-Length', String(CROSS_ORIGIN_PIXEL.byteLength))
+    response.setHeader('Cache-Control', 'no-store')
+    response.end(CROSS_ORIGIN_PIXEL)
+  })
+  await new Promise<void>((resolve, reject) => {
+    crossOriginAssetServer.once('error', reject)
+    crossOriginAssetServer.listen(0, '127.0.0.1', resolve)
+  })
+
+  const crossOriginAddress = crossOriginAssetServer.address()
+  if (!crossOriginAddress || typeof crossOriginAddress === 'string') {
+    throw new Error('Failed to get cross-origin asset server address')
+  }
+  crossOriginAssetServerUrl = `http://127.0.0.1:${crossOriginAddress.port}`
+
   server = await preview({
     root: PLAYGROUND_DIR,
-    plugins:
-      SERVICE_WORKER_RESPONSE_DELAY > 0
+    plugins: [
+      serveHostFetchProbe(),
+      ...(SERVICE_WORKER_RESPONSE_DELAY > 0
         ? [delayServiceWorkerResponse(SERVICE_WORKER_RESPONSE_DELAY)]
-        : [],
+        : [])
+    ],
     preview: {
       port: 0,
       strictPort: false,
@@ -261,9 +353,13 @@ beforeAll(async () => {
 }, 120000)
 
 afterAll(async () => {
-  await page?.close()
-  await browser?.close()
-  await server?.close()
+  try {
+    await page?.close()
+    await browser?.close()
+    await server?.close()
+  } finally {
+    await closeHttpServer(crossOriginAssetServer)
+  }
   debug('Cleanup complete')
 })
 
@@ -395,6 +491,65 @@ if (import.meta.hot) {
         }
       }
     )
+  })
+
+  describe('fetch routing', () => {
+    test('leaves cross-origin images to the browser network path', async () => {
+      expect(await page.evaluate(() => crossOriginIsolated)).toBe(true)
+
+      const requestUrl = `${crossOriginAssetServerUrl}/pixel.png?probe=${Date.now()}`
+      const { result, response } = await captureResponse(requestUrl, () =>
+        page.evaluate(
+          url =>
+            new Promise<'load' | 'error'>(resolve => {
+              const image = new Image()
+              image.hidden = true
+              image.onload = () => {
+                image.remove()
+                resolve('load')
+              }
+              image.onerror = () => {
+                image.remove()
+                resolve('error')
+              }
+              document.body.append(image)
+              image.src = url
+            }),
+          requestUrl
+        )
+      )
+
+      expect(result).toBe('load')
+      expect(response?.status()).toBe(200)
+      expect(response?.fromServiceWorker()).toBe(false)
+    })
+
+    test('leaves same-origin requests outside basePath to the browser network path', async () => {
+      const requestUrl = `${serverUrl}${HOST_FETCH_PROBE_PATH}?probe=${Date.now()}`
+      const { result, response } = await captureResponse(requestUrl, () =>
+        page.evaluate(async url => (await fetch(url)).text(), requestUrl)
+      )
+
+      expect(result).toBe('host-owned')
+      expect(response?.status()).toBe(200)
+      expect(response?.fromServiceWorker()).toBe(false)
+    })
+
+    test('keeps same-origin preview files on the Service Worker path', async () => {
+      const filePath = '/fetch-routing-preview-owned.js'
+      const content = 'export const routingProbe = "preview-owned"'
+      await addPreviewFiles({ [filePath]: content })
+      await waitForPreviewBodyContaining(`${filePath}?import`, 'preview-owned')
+
+      const requestUrl = `${serverUrl}/__preview__${filePath}?import&probe=${Date.now()}`
+      const { result, response } = await captureResponse(requestUrl, () =>
+        page.evaluate(async url => (await fetch(url)).text(), requestUrl)
+      )
+
+      expect(result).toContain('preview-owned')
+      expect(response?.status()).toBe(200)
+      expect(response?.fromServiceWorker()).toBe(true)
+    })
   })
 
   describe('filesystem security', () => {


### PR DESCRIPTION
## Summary

Limit the Vrowzer service worker fetch handler to same-origin HTTP(S) requests owned by the configured `basePath`. Cross-origin requests, host requests outside the preview namespace, non-HTTP URLs, and internal Rolldown assets now bypass Hono and retain native browser fetch semantics.

## Validation

Added table-driven routing coverage and browser integration checks for cross-origin images, host-owned endpoints, and preview resources. Verified the Issue #28 reproduction, unit/integration/E2E suites, type checking, formatting/linting, and monorepo builds.

Closes #28