### PR TITLE
feat(vrowzer): support multiple preview sessions

### DIFF
--- a/e2e/playground/alias/index.ts
+++ b/e2e/playground/alias/index.ts
@@ -19,7 +19,7 @@ async function init() {
     return
   }
 
-  vrowzer.mount(document.getElementById('app')!)
+  vrowzer.mount(document.getElementById('app')!, { id: 'preview' })
   statusEl.textContent = 'Ready'
 
   // Expose for E2E test access

--- a/e2e/playground/define/index.ts
+++ b/e2e/playground/define/index.ts
@@ -19,7 +19,7 @@ async function init() {
     return
   }
 
-  vrowzer.mount(document.getElementById('app')!)
+  vrowzer.mount(document.getElementById('app')!, { id: 'preview' })
   statusEl.textContent = 'Ready'
 
   // Expose for E2E test access

--- a/e2e/vite-react/index.ts
+++ b/e2e/vite-react/index.ts
@@ -19,7 +19,7 @@ async function init() {
     return
   }
 
-  vrowzer.mount(document.getElementById('app')!)
+  vrowzer.mount(document.getElementById('app')!, { id: 'preview' })
   statusEl.textContent = 'Ready'
 
   // Expose for E2E test access

--- a/e2e/vite-svelte/index.ts
+++ b/e2e/vite-svelte/index.ts
@@ -19,7 +19,7 @@ async function init() {
     return
   }
 
-  vrowzer.mount(document.getElementById('app')!)
+  vrowzer.mount(document.getElementById('app')!, { id: 'preview' })
   statusEl.textContent = 'Ready'
 
   // Expose for E2E test access

--- a/e2e/vite-vanilla/index.ts
+++ b/e2e/vite-vanilla/index.ts
@@ -19,7 +19,7 @@ async function init() {
     return
   }
 
-  vrowzer.mount(document.getElementById('app')!)
+  vrowzer.mount(document.getElementById('app')!, { id: 'preview' })
   statusEl.textContent = 'Ready'
 
   // Expose for E2E test access

--- a/e2e/vite-vue/index.ts
+++ b/e2e/vite-vue/index.ts
@@ -19,7 +19,7 @@ async function init() {
     return
   }
 
-  vrowzer.mount(document.getElementById('app')!)
+  vrowzer.mount(document.getElementById('app')!, { id: 'preview' })
   statusEl.textContent = 'Ready'
 
   // Expose for E2E test access

--- a/packages/play-vrowzer/src/App.vue
+++ b/packages/play-vrowzer/src/App.vue
@@ -103,7 +103,7 @@ onMounted(async () => {
 
   // Mount preview iframe
   if (previewContainer.value) {
-    await vrowzer.mount(previewContainer.value)
+    vrowzer.mount(previewContainer.value, { id: 'preview' })
   }
 
   isReady.value = true

--- a/packages/vite-dev-server/src/client/client.ts
+++ b/packages/vite-dev-server/src/client/client.ts
@@ -49,6 +49,7 @@ const hmrTimeout = __HMR_TIMEOUT__
 const wsToken = __WS_TOKEN__
 const isBundleMode = __BUNDLED_DEV__
 const forwardConsole = __SERVER_FORWARD_CONSOLE__
+let willUnload = false
 
 const transport = normalizeModuleRunnerTransport(
   (() => {
@@ -65,15 +66,17 @@ const transport = normalizeModuleRunnerTransport(
         try {
           await transport.connect(handlers)
         } catch (e) {
-          const currentScriptHostURL = new URL(import.meta.url)
-          const currentScriptHost =
-            currentScriptHostURL.host +
-            currentScriptHostURL.pathname.replace(/@vite\/client$/, '')
-          console.error(
-            '[vrowzer] failed to connect to MessageChannel.\n' +
-            'your current setup:\n' +
-            `  (browser) ${currentScriptHost} <--[Message Channel]--> ${serverHost} (server: service worker)\n`,
-          )
+          if (!willUnload) {
+            const currentScriptHostURL = new URL(import.meta.url)
+            const currentScriptHost =
+              currentScriptHostURL.host +
+              currentScriptHostURL.pathname.replace(/@vite\/client$/, '')
+            console.error(
+              '[vrowzer] failed to connect to MessageChannel.\n' +
+                'your current setup:\n' +
+                `  (browser) ${currentScriptHost} <--[Message Channel]--> ${serverHost} (server: service worker)\n`,
+            )
+          }
           throw e
         }
       },
@@ -157,11 +160,16 @@ const transport = normalizeModuleRunnerTransport(
 //   })(),
 // )
 
-let willUnload = false
 if (typeof window !== 'undefined') {
   // window can be misleadingly defined in a worker if using define (see #19307)
   window.addEventListener?.('beforeunload', () => {
     willUnload = true
+  })
+  window.addEventListener?.('pagehide', (event) => {
+    willUnload = true
+    if (!event.persisted) {
+      void transport.disconnect?.()
+    }
   })
 }
 
@@ -246,7 +254,7 @@ const hmrClient = new HMRClient(
 )
 
 console.log('[vrowzer] connecting to HMR MessageChannel server...')
-transport.connect!(createHMRHandler(handleMessage))
+void Promise.resolve(transport.connect!(createHMRHandler(handleMessage))).catch(() => {})
 setupForwardConsoleHandler(transport, forwardConsole)
 
 async function handleMessage(payload: HotPayload) {

--- a/packages/vite-dev-server/src/node/server/ws.test.ts
+++ b/packages/vite-dev-server/src/node/server/ws.test.ts
@@ -6,6 +6,7 @@ import type { ResolvedConfig } from '../config'
 
 type MessageListener = (event: MessageEvent) => void
 type ErrorListener = (event: MessageEvent) => void
+type CloseListener = () => void
 
 // Store for accessing mock internals
 const mockSafePortMap = new WeakMap<MessagePort, ReturnType<typeof createMockSafePort>>()
@@ -13,6 +14,7 @@ const mockSafePortMap = new WeakMap<MessagePort, ReturnType<typeof createMockSaf
 function createMockSafePort(rawPort: MessagePort) {
   const messageListeners: Set<MessageListener> = new Set()
   const errorListeners: Set<ErrorListener> = new Set()
+  const closeListeners: Set<CloseListener> = new Set()
 
   const safePort = {
     raw: rawPort,
@@ -22,10 +24,12 @@ function createMockSafePort(rawPort: MessagePort) {
     on: vi.fn((type: string, handler: EventListener) => {
       if (type === 'message') {messageListeners.add(handler as MessageListener)}
       if (type === 'messageerror') {errorListeners.add(handler as ErrorListener)}
+      if (type === 'close') {closeListeners.add(handler as CloseListener)}
     }),
     off: vi.fn((type: string, handler: EventListener) => {
       if (type === 'message') {messageListeners.delete(handler as MessageListener)}
       if (type === 'messageerror') {errorListeners.delete(handler as ErrorListener)}
+      if (type === 'close') {closeListeners.delete(handler as CloseListener)}
     }),
     once: vi.fn(),
     emit: vi.fn(),
@@ -42,6 +46,9 @@ function createMockSafePort(rawPort: MessagePort) {
     },
     simulateError: (err: unknown) => {
       errorListeners.forEach(h => h(err as MessageEvent))
+    },
+    simulateClose: () => {
+      closeListeners.forEach(h => h())
     }
   }
 
@@ -250,6 +257,61 @@ describe('createMessageChannelServer', () => {
   })
 
   describe('close', () => {
+    test('removes an individually closed client from future broadcasts', () => {
+      const config = createMockConfig()
+      const port1 = createMockMessagePort()
+      const port2 = createMockMessagePort()
+      const ws = createMessageChannelServer(config)
+
+      ws.handlePort(port1, 'client-1')
+      ws.handlePort(port2, 'client-2')
+      ws.listen()
+
+      const safePort1 = getMockSafePort(port1)
+      const safePort2 = getMockSafePort(port2)
+      safePort1.simulateClose()
+
+      expect(ws.clients.size).toBe(1)
+
+      const payload = { type: 'update' as const, updates: [] }
+      ws.send(payload)
+
+      expect(safePort1.postMessage).not.toHaveBeenCalledWith(payload)
+      expect(safePort2.postMessage).toHaveBeenCalledWith(payload)
+    })
+
+    test('emits one client disconnect event for an individually closed client', () => {
+      const config = createMockConfig()
+      const port = createMockMessagePort()
+      const ws = createMessageChannelServer(config)
+      const disconnectHandler = vi.fn()
+
+      ws.on('vite:client:disconnect', disconnectHandler)
+      connectClient(ws, port, 'client-1')
+
+      getMockSafePort(port).simulateClose()
+      getMockSafePort(port).simulateClose()
+
+      expect(disconnectHandler).toHaveBeenCalledTimes(1)
+      expect(disconnectHandler).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ port, clientId: 'client-1' })
+      )
+    })
+
+    test('removes a pending client that closes before listen', () => {
+      const config = createMockConfig()
+      const port = createMockMessagePort()
+      const ws = createMessageChannelServer(config)
+
+      ws.handlePort(port, 'client-1')
+      expect(ws.clients.size).toBe(1)
+
+      getMockSafePort(port).simulateClose()
+
+      expect(ws.clients.size).toBe(0)
+    })
+
     test('sends disconnect event to all clients', async () => {
       const config = createMockConfig()
       const port = createMockMessagePort()
@@ -290,6 +352,20 @@ describe('createMessageChannelServer', () => {
       await ws.close()
 
       expect(closeHandler).toHaveBeenCalled()
+    })
+
+    test('emits one client disconnect event per client when server closes', async () => {
+      const config = createMockConfig()
+      const port = createMockMessagePort()
+      const ws = createMessageChannelServer(config)
+      const disconnectHandler = vi.fn()
+
+      ws.on('vite:client:disconnect', disconnectHandler)
+      connectClient(ws, port, 'client-1')
+
+      await ws.close()
+
+      expect(disconnectHandler).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/packages/vite-dev-server/src/node/server/ws.ts
+++ b/packages/vite-dev-server/src/node/server/ws.ts
@@ -197,6 +197,7 @@ export function createMessageChannelServer(
   const safePorts = new Set<SafeMessagePort>()
   const customListeners = new Map<string, Set<MessageChannelCustomListener<any>>>()
   const clientsMap = new WeakMap<SafeMessagePort, MessageChannelClient>()
+  const clientIdsMap = new WeakMap<SafeMessagePort, string>()
   const serverEmitter = Emitter<{ connection: MessagePort; close: void; error: Error }>()
 
   // On page reloads, if a file fails to compile and returns 500, the server
@@ -225,6 +226,18 @@ export function createMessageChannelServer(
     }
   }
 
+  function removeClient(safePort: SafeMessagePort): void {
+    if (!safePorts.delete(safePort)) {
+      return
+    }
+    emitCustomEvent(
+      'vite:client:disconnect',
+      undefined,
+      safePort,
+      clientIdsMap.get(safePort),
+    )
+  }
+
   /**
    * Activate a port: send handshake messages and buffered payloads
    */
@@ -251,6 +264,9 @@ export function createMessageChannelServer(
   function handlePort(rawPort: MessagePort, clientId?: string) {
     const safePort = safeMessagePort<HotPayload>(rawPort)
     safePorts.add(safePort)
+    if (clientId !== undefined) {
+      clientIdsMap.set(safePort, clientId)
+    }
 
     // Set up message handler
     safePort.on('message', msgEvent => {
@@ -272,6 +288,10 @@ export function createMessageChannelServer(
       //   error: err,
       // })
       serverEmitter.emit('error', err as unknown as Error)
+    })
+
+    safePort.on('close', () => {
+      removeClient(safePort)
     })
 
     // If already listening, activate immediately
@@ -364,14 +384,14 @@ export function createMessageChannelServer(
       isListening = true
       // Activate any ports registered before listen()
       for (const safePort of safePorts) {
-        activatePort(safePort, safePort.raw)
+        activatePort(safePort, safePort.raw, clientIdsMap.get(safePort))
       }
     },
 
     async close() {
       // Notify all clients of disconnection
-      for (const safePort of safePorts) {
-        emitCustomEvent('vite:client:disconnect', undefined, safePort)
+      for (const safePort of [...safePorts]) {
+        removeClient(safePort)
         safePort.postMessage({
           type: 'custom',
           event: 'vite:ws:disconnect',

--- a/packages/vite-dev-server/src/shared/moduleRunnerTransport.test.ts
+++ b/packages/vite-dev-server/src/shared/moduleRunnerTransport.test.ts
@@ -141,6 +141,7 @@ describe('createMessageChannelModuleRunnerTransport', () => {
           onDisconnection: vi.fn(),
         })
       ).rejects.toThrow('MessageChannel connection timeout')
+      expect(mockPort1Close).toHaveBeenCalledTimes(1)
     })
 
     it('calls onMessage for received messages after connection', async () => {
@@ -222,6 +223,26 @@ describe('createMessageChannelModuleRunnerTransport', () => {
   })
 
   describe('disconnect()', () => {
+    it('closes the port and rejects a pending connection', async () => {
+      const mockPostMessage = vi.fn()
+      const transport = createMessageChannelModuleRunnerTransport(mockPostMessage, {
+        timeout: 1000,
+        pingInterval: 0,
+      })
+
+      const connectPromise = transport.connect({
+        onMessage: vi.fn(),
+        onDisconnection: vi.fn(),
+      })
+
+      transport.disconnect()
+
+      expect(mockPort1Close).toHaveBeenCalledTimes(1)
+      await expect(connectPromise).rejects.toThrow(
+        'MessageChannel connection closed before confirmation'
+      )
+    })
+
     it('closes the port', async () => {
       const mockPostMessage = vi.fn()
       const transport = createMessageChannelModuleRunnerTransport(mockPostMessage, {
@@ -476,7 +497,7 @@ describe('normalizeModuleRunnerTransport', () => {
       expect(mockDisconnect).not.toHaveBeenCalled()
     })
 
-    it('does nothing if disconnect is called while connecting (not yet connected)', async () => {
+    it('disconnects immediately while connecting and stays disconnected', async () => {
       let resolveConnect: () => void
       const connectPromise = new Promise<void>((resolve) => {
         resolveConnect = resolve
@@ -492,18 +513,16 @@ describe('normalizeModuleRunnerTransport', () => {
       const normalized = normalizeModuleRunnerTransport(transport)
 
       const connectP = normalized.connect!()
-      // disconnect is called before connect completes, so isConnected is still false
       await normalized.disconnect!()
 
-      // disconnect should return early because isConnected is false
-      expect(mockDisconnect).not.toHaveBeenCalled()
+      expect(mockDisconnect).toHaveBeenCalledTimes(1)
 
       resolveConnect!()
       await connectP
 
-      // Now we can disconnect properly
-      await normalized.disconnect!()
-      expect(mockDisconnect).toHaveBeenCalled()
+      await expect(normalized.send({ type: 'ping' } as any)).rejects.toBeInstanceOf(
+        SendBeforeConnectError
+      )
     })
   })
 

--- a/packages/vite-dev-server/src/shared/moduleRunnerTransport.ts
+++ b/packages/vite-dev-server/src/shared/moduleRunnerTransport.ts
@@ -194,7 +194,8 @@ export const normalizeModuleRunnerTransport = (
 ): NormalizedModuleRunnerTransport => {
   const invokeableTransport = createInvokeableTransport(transport)
 
-  let isConnected = !invokeableTransport.connect
+  let connectionState: 'disconnected' | 'connecting' | 'connected' =
+    invokeableTransport.connect ? 'disconnected' : 'connected'
   let connectingPromise: Promise<void> | undefined
 
   return {
@@ -202,35 +203,51 @@ export const normalizeModuleRunnerTransport = (
     ...(invokeableTransport.connect
       ? {
         async connect(onMessage) {
-          if (isConnected) { return }
+          if (connectionState === 'connected') { return }
           if (connectingPromise) {
             await connectingPromise
             return
           }
 
-          const maybePromise = invokeableTransport.connect!({
-            onMessage: onMessage ?? (() => { }),
-            onDisconnection() {
-              isConnected = false
-            },
-          })
-          if (maybePromise) {
-            connectingPromise = maybePromise
-            await connectingPromise
-            connectingPromise = undefined
+          connectionState = 'connecting'
+          let connectResult: Promise<void> | void
+          try {
+            connectResult = invokeableTransport.connect!({
+              onMessage: onMessage ?? (() => { }),
+              onDisconnection() {
+                connectionState = 'disconnected'
+              },
+            })
+          } catch (error) {
+            connectionState = 'disconnected'
+            throw error
           }
-          isConnected = true
+
+          const currentConnectingPromise = Promise.resolve(connectResult)
+          connectingPromise = currentConnectingPromise
+          try {
+            await currentConnectingPromise
+            if (connectionState === 'connecting') {
+              connectionState = 'connected'
+            }
+          } catch (error) {
+            if (connectionState === 'connecting') {
+              connectionState = 'disconnected'
+            }
+            throw error
+          } finally {
+            if (connectingPromise === currentConnectingPromise) {
+              connectingPromise = undefined
+            }
+          }
         },
       }
       : {}),
     ...(invokeableTransport.disconnect
       ? {
         async disconnect() {
-          if (!isConnected) { return }
-          if (connectingPromise) {
-            await connectingPromise
-          }
-          isConnected = false
+          if (connectionState === 'disconnected') { return }
+          connectionState = 'disconnected'
           await invokeableTransport.disconnect!()
         },
       }
@@ -238,22 +255,24 @@ export const normalizeModuleRunnerTransport = (
     async send(data) {
       if (!invokeableTransport.send) { return }
 
-      if (!isConnected) {
+      if (connectionState !== 'connected') {
         if (connectingPromise) {
           await connectingPromise
-        } else {
-          throw new SendBeforeConnectError('send was called before connect')
         }
+      }
+      if (connectionState !== 'connected') {
+        throw new SendBeforeConnectError('send was called before connect')
       }
       await invokeableTransport.send(data)
     },
     async invoke(name, data) {
-      if (!isConnected) {
+      if (connectionState !== 'connected') {
         if (connectingPromise) {
           await connectingPromise
-        } else {
-          throw new SendBeforeConnectError('invoke was called before connect')
         }
+      }
+      if (connectionState !== 'connected') {
+        throw new SendBeforeConnectError('invoke was called before connect')
       }
       return invokeableTransport.invoke(name, data)
     },
@@ -291,7 +310,8 @@ export const createMessageChannelModuleRunnerTransport = (
     async connect({ onMessage, onDisconnection }) {
       // Create `MessageChannel`
       const channel = new MessageChannel()
-      sourcePort = safeMessagePort<SourcePortType>(channel.port1)
+      const currentSourcePort = safeMessagePort<SourcePortType>(channel.port1)
+      sourcePort = currentSourcePort
       const clientId = nanoid()
 
       // Transfer `port2` to host via `postMessage`
@@ -302,31 +322,70 @@ export const createMessageChannelModuleRunnerTransport = (
       )
 
       // Wait for connection confirmation (`vite:mc:init` echo from remote)
-      await new Promise<void>((resolve, reject) => {
-        const timeoutId = setTimeout(() => {
-          reject(new Error('MessageChannel connection timeout'))
-        }, timeout)
+      try {
+        await new Promise<void>((resolve, reject) => {
+          let settled = false
+          const timeoutId = setTimeout(() => {
+            settle(() => reject(new Error('MessageChannel connection timeout')))
+          }, timeout)
 
-        sourcePort!.once('message', event => {
-          if (event.data.type === MC_INIT_EVENT) {
-            clearTimeout(timeoutId)
-            if (event.data.clientId !== clientId) {
-              reject(new Error(`Client ID mismatch: expected ${clientId}, got ${event.data.clientId}`))
-            } else {
-              resolve()
+          let stopMessageListener: () => void = () => {}
+          let stopCloseListener: () => void = () => {}
+          const settle = (callback: () => void): void => {
+            if (settled) {
+              return
             }
+            settled = true
+            clearTimeout(timeoutId)
+            stopMessageListener()
+            stopCloseListener()
+            callback()
           }
+
+          stopMessageListener = currentSourcePort.once('message', event => {
+            if (event.data.type === MC_INIT_EVENT) {
+              const receivedClientId = event.data.clientId
+              if (receivedClientId !== clientId) {
+                settle(() =>
+                  reject(
+                    new Error(
+                      `Client ID mismatch: expected ${clientId}, got ${receivedClientId}`,
+                    ),
+                  ),
+                )
+              } else {
+                settle(resolve)
+              }
+            }
+          })
+          stopCloseListener = currentSourcePort.once('close', () => {
+            settle(() =>
+              reject(
+                new Error('MessageChannel connection closed before confirmation'),
+              ),
+            )
+          })
         })
-      })
+      } catch (error) {
+        if (sourcePort === currentSourcePort) {
+          currentSourcePort.close()
+          sourcePort = undefined
+        }
+        throw error
+      }
+
+      if (sourcePort !== currentSourcePort) {
+        throw new Error('MessageChannel connection closed before confirmation')
+      }
 
       // Set up message listener
-      sourcePort.on('message', (event) => {
+      currentSourcePort.on('message', (event) => {
         const data = event.data
         if (event.data.type === 'custom' && event.data.event === WS_DISCONNECT_EVENT) {
           onMessage({
             type: 'custom',
             event: WS_DISCONNECT_EVENT,
-            data: { port: sourcePort }
+            data: { port: currentSourcePort }
           })
           onDisconnection()
           return
@@ -338,7 +397,7 @@ export const createMessageChannelModuleRunnerTransport = (
       onMessage({
         type: 'custom',
         event: WS_CONNECT_EVENT,
-        data: { port: sourcePort }
+        data: { port: currentSourcePort }
       })
 
       // Set up ping interval for keep-alive (optional)

--- a/packages/vite-plugin/src/ide/IdeApp.vue
+++ b/packages/vite-plugin/src/ide/IdeApp.vue
@@ -107,7 +107,7 @@ onMounted(async () => {
   }
 
   if (previewContainer.value) {
-    vrowzer.mount(previewContainer.value)
+    vrowzer.mount(previewContainer.value, { id: 'preview' })
   }
 
   isReady.value = true

--- a/packages/vrowzer/README.md
+++ b/packages/vrowzer/README.md
@@ -60,7 +60,7 @@ const ready = await vrowzer.ready({
 
 if (ready) {
   // Mount preview iframe into a container element
-  vrowzer.mount(document.getElementById('preview-container'))
+  vrowzer.mount(document.getElementById('preview-container'), { id: 'preview' })
 }
 
 // Update files (triggers HMR)
@@ -158,6 +158,7 @@ Set this option to `0` for an immediate timeout. It does not apply to Service Wo
 #### `ready(config): Promise<boolean>`
 
 Initializes the preview system: creates Web Worker and Service Worker, establishes a MessageChannel between them, and syncs initial files.
+Call this method once per Vrowzer instance. Use one initialized Vrowzer instance per page and share it with every preview session.
 
 ```ts
 const ready = await vrowzer.ready({
@@ -168,12 +169,55 @@ const ready = await vrowzer.ready({
 })
 ```
 
-#### `mount(container): void`
+#### `mount(container, options): PreviewSession`
 
-Mounts a preview iframe into the given DOM element. The iframe uses `credentialless` and `sandbox="allow-scripts allow-same-origin"` attributes, and loads content via the Service Worker using a `srcdoc` bootstrap.
+Mounts a preview iframe into the given DOM element. `options.id` is a host-defined, non-empty pane identity. Mounting the same ID again returns the existing session without moving or reloading its iframe; the first container and params remain in effect.
 
 ```ts
-vrowzer.mount(document.getElementById('preview'))
+const desktop = vrowzer.mount(document.getElementById('desktop'), {
+  id: 'desktop',
+  params: { viewport: 'desktop' }
+})
+const mobile = vrowzer.mount(document.getElementById('mobile'), {
+  id: 'mobile',
+  params: { viewport: 'mobile' }
+})
+```
+
+Each iframe uses `credentialless` and `sandbox="allow-scripts allow-same-origin"`, and loads content through a `srcdoc` bootstrap. Before preview scripts run, Vrowzer exposes the session context through `window.__VROWZER_PREVIEW__` and `document.documentElement.dataset.vrowzerPreviewId`.
+
+```ts
+const { id, params } = window.__VROWZER_PREVIEW__!
+```
+
+Changing host focus does not affect a session. Keep the session mounted to preserve its current document.
+
+#### `getSession(id): PreviewSession | undefined`
+
+Returns the currently mounted session for a host-defined ID.
+
+#### `sessions(): readonly PreviewSession[]`
+
+Returns a frozen snapshot of all currently mounted sessions.
+
+#### `reloadPreview(target?): void`
+
+Reloads the session selected by an ID or `PreviewSession`. Omitting the target reloads every mounted session.
+
+```ts
+vrowzer.reloadPreview(mobile)
+desktop.reload()
+vrowzer.reloadPreview()
+```
+
+#### `unmount(target?): void`
+
+Removes the selected session iframe and its HMR client. Omitting the target unmounts every iframe. The shared Service Worker, Web Worker, and virtual filesystem remain ready.
+
+```ts
+vrowzer.unmount('mobile')
+desktop.unmount()
+vrowzer.unmount()
 ```
 
 #### `updateFile(path, content): void`
@@ -191,10 +235,6 @@ Adds a new file to the virtual filesystem.
 #### `deleteFile(path): void`
 
 Deletes a file from the virtual filesystem.
-
-#### `reloadPreview(): void`
-
-Reloads the preview iframe.
 
 ## 🏗️ Architecture
 

--- a/packages/vrowzer/docs/default/interfaces/PreviewContext.md
+++ b/packages/vrowzer/docs/default/interfaces/PreviewContext.md
@@ -1,0 +1,16 @@
+# Interface: PreviewContext
+
+Context exposed to the mounted preview document.
+
+## Signature
+
+```ts
+export interface PreviewContext
+```
+
+## Properties
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `id` _(readonly)_ | `string` | Host-defined preview session identity. |
+| `params` _(optional, readonly)_ | `Readonly<Record<string, string>>` | Optional values provided when the preview session was mounted. |

--- a/packages/vrowzer/docs/default/interfaces/PreviewMountOptions.md
+++ b/packages/vrowzer/docs/default/interfaces/PreviewMountOptions.md
@@ -1,0 +1,16 @@
+# Interface: PreviewMountOptions
+
+Options for mounting a preview session.
+
+## Signature
+
+```ts
+export interface PreviewMountOptions
+```
+
+## Properties
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Host-defined identity for the preview pane. |
+| `params` _(optional)_ | `Record<string, string>` | Values exposed to the preview document before its scripts run. |

--- a/packages/vrowzer/docs/default/interfaces/PreviewSession.md
+++ b/packages/vrowzer/docs/default/interfaces/PreviewSession.md
@@ -1,0 +1,45 @@
+# Interface: PreviewSession
+
+A mounted preview iframe managed by a [Vrowzer](/packages/vrowzer/docs/default/interfaces/Vrowzer.md) instance.
+
+## Signature
+
+```ts
+export interface PreviewSession
+```
+
+## Properties
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `container` _(readonly)_ | `HTMLElement` | Container that owns the iframe. |
+| `id` _(readonly)_ | `string` | Host-defined preview session identity. |
+| `iframe` _(readonly)_ | `HTMLIFrameElement` | Iframe used by this preview session. |
+
+## Methods
+
+### reload()
+
+```ts
+reload(): void;
+```
+
+Reloads only this preview document.
+
+#### Returns
+
+`void`
+
+***
+
+### unmount()
+
+```ts
+unmount(): void;
+```
+
+Removes only this preview document.
+
+#### Returns
+
+`void`

--- a/packages/vrowzer/docs/default/interfaces/Vrowzer.md
+++ b/packages/vrowzer/docs/default/interfaces/Vrowzer.md
@@ -55,10 +55,30 @@ Deletes a specific file from the preview environment.
 
 ***
 
+### getSession()
+
+```ts
+getSession(id: string): PreviewSession | undefined;
+```
+
+Returns the currently mounted preview session for an ID.
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Host-defined preview session identity. |
+
+#### Returns
+
+[`PreviewSession`](/packages/vrowzer/docs/default/interfaces/PreviewSession.md) | `undefined`
+
+***
+
 ### mount()
 
 ```ts
-mount(container: HTMLElement): void;
+mount(container: HTMLElement, options: PreviewMountOptions): PreviewSession;
 ```
 
 Mounts the preview system to a specified container element in the DOM.
@@ -66,15 +86,19 @@ Mounts the preview system to a specified container element in the DOM.
 Creates a credentialless iframe with srcdoc bootstrap that fetches
 the preview HTML via the Service Worker.
 
+Reusing an existing session ID returns the original session without reloading or moving it.
+The container and params from the first mount remain in effect.
+
 #### Parameters
 
 | Name | Type | Description |
 | --- | --- | --- |
 | `container` | `HTMLElement` | A DOM element where the preview iframe will be mounted. |
+| `options` | [`PreviewMountOptions`](/packages/vrowzer/docs/default/interfaces/PreviewMountOptions.md) | Preview identity and context values. |
 
 #### Returns
 
-`void`
+[`PreviewSession`](/packages/vrowzer/docs/default/interfaces/PreviewSession.md) — The mounted preview session.
 
 ***
 
@@ -88,6 +112,7 @@ Ready for preview system initialization.
 
 This method initializes the Web Worker, Service Worker, and MessageChannel,
 then syncs initial files to both workers.
+It can only be called once per Vrowzer instance.
 
 #### Parameters
 
@@ -104,10 +129,51 @@ then syncs initial files to both workers.
 ### reloadPreview()
 
 ```ts
-reloadPreview(): void;
+reloadPreview(target?: PreviewSessionRef): void;
 ```
 
-Reloads the preview iframe
+Reloads one preview session, or every session when no target is provided.
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `target` | [`PreviewSessionRef`](/packages/vrowzer/docs/default/type-aliases/PreviewSessionRef.md) | A session ID or mounted session object. _(optional)_ |
+
+#### Returns
+
+`void`
+
+***
+
+### sessions()
+
+```ts
+sessions(): readonly PreviewSession[];
+```
+
+Returns a snapshot of all currently mounted preview sessions.
+
+#### Returns
+
+`readonly` [`PreviewSession`](/packages/vrowzer/docs/default/interfaces/PreviewSession.md)\[\]
+
+***
+
+### unmount()
+
+```ts
+unmount(target?: PreviewSessionRef): void;
+```
+
+Unmounts one preview session, or every session when no target is provided.
+The shared Service Worker, Web Worker, and virtual filesystem remain active.
+
+#### Parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `target` | [`PreviewSessionRef`](/packages/vrowzer/docs/default/type-aliases/PreviewSessionRef.md) | A session ID or mounted session object. _(optional)_ |
 
 #### Returns
 

--- a/packages/vrowzer/docs/default/type-aliases/PreviewSessionRef.md
+++ b/packages/vrowzer/docs/default/type-aliases/PreviewSessionRef.md
@@ -1,0 +1,9 @@
+# Type Alias: PreviewSessionRef
+
+A preview session target accepted by lifecycle methods.
+
+## Signature
+
+```ts
+export type PreviewSessionRef = string | PreviewSession
+```

--- a/packages/vrowzer/docs/index.md
+++ b/packages/vrowzer/docs/index.md
@@ -21,7 +21,7 @@ const ready = await vrowzer.ready({
 
 if (ready) {
   // Mount preview iframe into a container element
-  vrowzer.mount(document.getElementById('preview-container'))
+  vrowzer.mount(document.getElementById('preview-container'), { id: 'preview' })
 }
 
 // Update files (triggers HMR)
@@ -44,6 +44,9 @@ vrowzer.updateFile(
 
 | Interface | Description |
 | ------ | ------ |
+| [PreviewContext](/packages/vrowzer/docs/default/interfaces/PreviewContext.md) | Context exposed to the mounted preview document. |
+| [PreviewMountOptions](/packages/vrowzer/docs/default/interfaces/PreviewMountOptions.md) | Options for mounting a preview session. |
+| [PreviewSession](/packages/vrowzer/docs/default/interfaces/PreviewSession.md) | A mounted preview iframe managed by a [Vrowzer](/packages/vrowzer/docs/default/interfaces/Vrowzer.md) instance. |
 | [Vrowzer](/packages/vrowzer/docs/default/interfaces/Vrowzer.md) | The main interface for the Vrowzer preview environment. |
 | [VrowzerConfig](/packages/vrowzer/docs/default/interfaces/VrowzerConfig.md) | VrowzerConfig defines the configuration options for [`Vrowzer.ready`](/packages/vrowzer/docs/default/interfaces/Vrowzer.md#method-ready) |
 | [VrowzerOptions](/packages/vrowzer/docs/default/interfaces/VrowzerOptions.md) | VrowzerOptions defines the configuration options for [Vrowzer](/packages/vrowzer/docs/default/interfaces/Vrowzer.md). |
@@ -52,5 +55,6 @@ vrowzer.updateFile(
 
 | Type Alias | Description |
 | ------ | ------ |
+| [PreviewSessionRef](/packages/vrowzer/docs/default/type-aliases/PreviewSessionRef.md) | A preview session target accepted by lifecycle methods. |
 | [VrowzerEventMap](/packages/vrowzer/docs/default/type-aliases/VrowzerEventMap.md) | Event map for [Vrowzer](/packages/vrowzer/docs/default/interfaces/Vrowzer.md). |
 

--- a/packages/vrowzer/integration/custom-base/main.ts
+++ b/packages/vrowzer/integration/custom-base/main.ts
@@ -26,7 +26,7 @@ async function init() {
       return
     }
 
-    vrowzer.mount(container)
+    vrowzer.mount(container, { id: 'preview' })
     status.textContent = 'Ready'
   } catch (error) {
     status.textContent = `Error: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/vrowzer/integration/playground/main.ts
+++ b/packages/vrowzer/integration/playground/main.ts
@@ -38,6 +38,7 @@ document.getElementById('app').innerHTML = \`
   <h1>Hello from Vrowzer!</h1>
   <p id="counter">count: 0</p>
 \`
+globalThis.__vrowzerContextAtScriptStart = globalThis.__VROWZER_PREVIEW__
 
 if (import.meta.hot) {
   import.meta.hot.accept()
@@ -52,7 +53,10 @@ if (import.meta.hot) {
     }
 
     status.textContent = 'Mounting preview...'
-    await vrowzer.mount(container)
+    vrowzer.mount(container, {
+      id: 'preview',
+      params: { viewport: 'primary' }
+    })
     status.textContent = 'Ready'
   } catch (error) {
     status.textContent = `Error: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/vrowzer/integration/playground/vite.config.ts
+++ b/packages/vrowzer/integration/playground/vite.config.ts
@@ -166,6 +166,50 @@ function postcssOnceExitWebWorkerPlugin(): Plugin {
   }
 }
 
+function hmrClientTrackingWebWorkerPlugin(): Plugin {
+  const virtualId = 'virtual:vrowzer-test-hmr-clients'
+  const resolvedVirtualId = `\0${virtualId}`
+  const clientIds = new Set<string>()
+  let runtimeServer: ViteDevServer | undefined
+
+  return {
+    name: 'vrowzer-test:hmr-client-tracking-web-worker',
+    apply: 'serve',
+    configureServer(server) {
+      const middlewares = (server as { middlewares?: unknown }).middlewares
+      if (server.config.root !== '/' || middlewares) {
+        return
+      }
+
+      runtimeServer = server
+      server.ws.on('vite:client:connect', (_data, client) => {
+        if (client.clientId) {
+          clientIds.add(client.clientId)
+        }
+      })
+      server.ws.on('vite:client:disconnect', (_data, client) => {
+        if (client.clientId) {
+          clientIds.delete(client.clientId)
+        }
+      })
+    },
+    resolveId(id) {
+      if (id === virtualId || id.startsWith(`${virtualId}?`)) {
+        return `\0${id}`
+      }
+    },
+    load(id) {
+      if (!id.startsWith(resolvedVirtualId)) {
+        return
+      }
+      if (!runtimeServer) {
+        throw new Error('Web Worker dev server is not available')
+      }
+      return `export default ${JSON.stringify([...clientIds])}`
+    }
+  }
+}
+
 export default defineConfig({
   server: {
     origin: 'https://assets.vrowzer.test'
@@ -174,6 +218,7 @@ export default defineConfig({
     trailingSlashWebWorkerPlugin(),
     fsHtmlProxyWebWorkerPlugin(),
     postcssOnceExitWebWorkerPlugin(),
+    hmrClientTrackingWebWorkerPlugin(),
     Vrowzer({
       auto: false,
       basePath: '/__preview__/',

--- a/packages/vrowzer/integration/vrowzer.integration-test.ts
+++ b/packages/vrowzer/integration/vrowzer.integration-test.ts
@@ -40,6 +40,7 @@ let serverUrl: string
 let crossOriginAssetServerUrl: string
 let pageConsoleLogs: string[] = []
 let delayedServiceWorkerRequests = 0
+let hmrClientProbeId = 0
 
 function delayServiceWorkerResponse(delay: number): Plugin {
   return {
@@ -130,6 +131,82 @@ async function addPreviewFiles(files: Record<string, string>): Promise<void> {
       vrowzer.addFile(filePath, content)
     }
   }, files)
+}
+
+function createMultiSessionSource(revision: string): string {
+  return `
+const context = globalThis.__VROWZER_PREVIEW__
+globalThis.__vrowzerContextAtScriptStart = context
+globalThis.__vrowzerBootToken = crypto.randomUUID()
+document.getElementById('app').innerHTML =
+  '<h1 data-preview-id="' + context.id + '">' + context.id + '</h1>' +
+  '<p data-revision="${revision}">${revision}</p>'
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}
+`
+}
+
+async function readHmrClientIds(): Promise<string[]> {
+  const probeId = ++hmrClientProbeId
+  const resultKey = `__vrowzerHmrClientProbe${probeId}`
+  const filePath = `/hmr-client-probe-${probeId}.js`
+  await addPreviewFiles({
+    [filePath]: `
+import clientIds from 'virtual:vrowzer-test-hmr-clients?probe=${probeId}'
+globalThis[${JSON.stringify(resultKey)}] = { clientIds }
+`
+  })
+
+  await page.evaluate(
+    ({ filePath, resultKey }) => {
+      const iframe = document.querySelector('#preview-container iframe') as HTMLIFrameElement | null
+      const iframeDocument = iframe?.contentDocument
+      const iframeWindow = iframe?.contentWindow as any
+      if (!iframeDocument || !iframeWindow) {
+        throw new Error('Primary preview iframe is not available')
+      }
+      delete iframeWindow[resultKey]
+      const script = iframeDocument.createElement('script')
+      script.type = 'module'
+      script.src = `/__preview__${filePath}`
+      iframeDocument.head.append(script)
+    },
+    { filePath, resultKey }
+  )
+
+  await expect
+    .poll(
+      () =>
+        page.evaluate(resultKey => {
+          const iframe = document.querySelector(
+            '#preview-container iframe'
+          ) as HTMLIFrameElement | null
+          return (iframe?.contentWindow as any)?.[resultKey]?.clientIds
+        }, resultKey),
+      { timeout: 10_000 }
+    )
+    .toBeTruthy()
+
+  return page.evaluate(resultKey => {
+    const iframe = document.querySelector('#preview-container iframe') as HTMLIFrameElement | null
+    return (iframe?.contentWindow as any)[resultKey].clientIds
+  }, resultKey)
+}
+
+async function waitForHmrClientCount(expectedCount: number): Promise<string[]> {
+  let clientIds: string[] = []
+  await expect
+    .poll(
+      async () => {
+        clientIds = await readHmrClientIds()
+        return clientIds.length
+      },
+      { timeout: 15_000 }
+    )
+    .toBe(expectedCount)
+  return clientIds
 }
 
 async function fetchFromPreview(requestPath: string): Promise<PreviewResponse> {
@@ -415,6 +492,25 @@ describe('Vrowzer E2E', () => {
       expect(text).toContain('Hello from Vrowzer!')
       expect(text).toContain('count: 0')
     }, 60000)
+
+    test('injects preview context before application scripts run', async () => {
+      const context = await page.evaluate(() => {
+        const iframe = document.querySelector(
+          '#preview-container iframe'
+        ) as HTMLIFrameElement | null
+        return {
+          captured: (iframe?.contentWindow as any)?.__vrowzerContextAtScriptStart,
+          current: (iframe?.contentWindow as any)?.__VROWZER_PREVIEW__,
+          dataset: iframe?.contentDocument?.documentElement.dataset.vrowzerPreviewId
+        }
+      })
+
+      expect(context).toEqual({
+        captured: { id: 'preview', params: { viewport: 'primary' } },
+        current: { id: 'preview', params: { viewport: 'primary' } },
+        dataset: 'preview'
+      })
+    })
   })
 
   describe('file operations', () => {
@@ -451,6 +547,278 @@ if (import.meta.hot) {
         )
         .toEqual({ updated: true, result: true })
     }, 30000)
+  })
+
+  describe('preview sessions', () => {
+    test('keeps multiple panes alive with targeted reload and unmount', async () => {
+      const dangerousMarker = '</script>\u2028\u2029'
+
+      await page.evaluate(source => {
+        ;(window as any).__vrowzer__.updateFile('/main.js', source)
+      }, createMultiSessionSource('multi-1'))
+
+      await expect
+        .poll(
+          () =>
+            page.evaluate(() =>
+              document
+                .querySelector('#preview-container iframe')
+                ?.contentDocument?.querySelector('[data-revision]')
+                ?.getAttribute('data-revision')
+            ),
+          { timeout: 15_000 }
+        )
+        .toBe('multi-1')
+
+      const mountResult = await page.evaluate(marker => {
+        const vrowzer = (window as any).__vrowzer__
+        const tabletContainer = document.createElement('div')
+        tabletContainer.id = 'preview-tablet'
+        const mobileContainer = document.createElement('div')
+        mobileContainer.id = 'preview-mobile'
+        const duplicateContainer = document.createElement('div')
+        duplicateContainer.id = 'preview-duplicate'
+        document.body.append(tabletContainer, mobileContainer, duplicateContainer)
+
+        const tablet = vrowzer.mount(tabletContainer, {
+          id: 'tablet',
+          params: { viewport: 'tablet' }
+        })
+        const mobile = vrowzer.mount(mobileContainer, {
+          id: 'mobile',
+          params: { marker, viewport: 'mobile' }
+        })
+        const duplicate = vrowzer.mount(duplicateContainer, {
+          id: 'mobile',
+          params: { viewport: 'duplicate' }
+        })
+        ;(window as any).__vrowzerMultiSessions = { mobile, tablet }
+
+        return {
+          duplicateIsSame: duplicate === mobile,
+          duplicateIframeCount: duplicateContainer.querySelectorAll('iframe').length,
+          sessionIds: vrowzer.sessions().map((session: { id: string }) => session.id)
+        }
+      }, dangerousMarker)
+
+      expect(mountResult).toEqual({
+        duplicateIsSame: true,
+        duplicateIframeCount: 0,
+        sessionIds: ['preview', 'tablet', 'mobile']
+      })
+
+      await page.waitForFunction(
+        () =>
+          ['preview-container', 'preview-tablet', 'preview-mobile'].every(containerId =>
+            document
+              .querySelector(`#${containerId} iframe`)
+              ?.contentDocument?.querySelector('[data-revision="multi-1"]')
+          ),
+        undefined,
+        { timeout: 30_000 }
+      )
+
+      const contexts = await page.evaluate(() =>
+        ['preview-container', 'preview-tablet', 'preview-mobile'].map(containerId => {
+          const iframe = document.querySelector(
+            `#${containerId} iframe`
+          ) as HTMLIFrameElement | null
+          const iframeWindow = iframe?.contentWindow as any
+          return {
+            captured: iframeWindow?.__vrowzerContextAtScriptStart,
+            current: iframeWindow?.__VROWZER_PREVIEW__,
+            dataset: iframe?.contentDocument?.documentElement.dataset.vrowzerPreviewId,
+            frozen: Object.isFrozen(iframeWindow?.__VROWZER_PREVIEW__),
+            paramsFrozen: Object.isFrozen(iframeWindow?.__VROWZER_PREVIEW__?.params)
+          }
+        })
+      )
+
+      expect(contexts).toEqual([
+        {
+          captured: { id: 'preview', params: { viewport: 'primary' } },
+          current: { id: 'preview', params: { viewport: 'primary' } },
+          dataset: 'preview',
+          frozen: true,
+          paramsFrozen: true
+        },
+        {
+          captured: { id: 'tablet', params: { viewport: 'tablet' } },
+          current: { id: 'tablet', params: { viewport: 'tablet' } },
+          dataset: 'tablet',
+          frozen: true,
+          paramsFrozen: true
+        },
+        {
+          captured: {
+            id: 'mobile',
+            params: { marker: dangerousMarker, viewport: 'mobile' }
+          },
+          current: {
+            id: 'mobile',
+            params: { marker: dangerousMarker, viewport: 'mobile' }
+          },
+          dataset: 'mobile',
+          frozen: true,
+          paramsFrozen: true
+        }
+      ])
+      const clientIdsBeforeReload = await waitForHmrClientCount(3)
+      expect(new Set(clientIdsBeforeReload).size).toBe(3)
+
+      await page.evaluate(source => {
+        ;(window as any).__vrowzer__.updateFile('/main.js', source)
+      }, createMultiSessionSource('multi-2'))
+
+      await page.waitForFunction(
+        () =>
+          ['preview-container', 'preview-tablet', 'preview-mobile'].every(containerId =>
+            document
+              .querySelector(`#${containerId} iframe`)
+              ?.contentDocument?.querySelector('[data-revision="multi-2"]')
+          ),
+        undefined,
+        { timeout: 30_000 }
+      )
+
+      const tokensBeforeReload = (await page.evaluate(() =>
+        Object.fromEntries(
+          ['preview-container', 'preview-tablet', 'preview-mobile'].map(containerId => {
+            const iframe = document.querySelector(
+              `#${containerId} iframe`
+            ) as HTMLIFrameElement | null
+            return [containerId, (iframe?.contentWindow as any)?.__vrowzerBootToken]
+          })
+        )
+      )) as Record<string, string>
+
+      await page.evaluate(() => {
+        ;(window as any).__vrowzerMultiSessions.mobile.reload()
+      })
+
+      await expect
+        .poll(
+          () =>
+            page.evaluate(previousToken => {
+              const iframe = document.querySelector(
+                '#preview-mobile iframe'
+              ) as HTMLIFrameElement | null
+              return {
+                revision: iframe?.contentDocument
+                  ?.querySelector('[data-revision]')
+                  ?.getAttribute('data-revision'),
+                tokenChanged: (iframe?.contentWindow as any)?.__vrowzerBootToken !== previousToken
+              }
+            }, tokensBeforeReload['preview-mobile']),
+          { timeout: 30_000 }
+        )
+        .toEqual({
+          revision: 'multi-2',
+          tokenChanged: true
+        })
+
+      const tokensAfterReload = (await page.evaluate(() =>
+        Object.fromEntries(
+          ['preview-container', 'preview-tablet', 'preview-mobile'].map(containerId => {
+            const iframe = document.querySelector(
+              `#${containerId} iframe`
+            ) as HTMLIFrameElement | null
+            return [containerId, (iframe?.contentWindow as any)?.__vrowzerBootToken]
+          })
+        )
+      )) as Record<string, string>
+      expect(tokensAfterReload['preview-container']).toBe(tokensBeforeReload['preview-container'])
+      expect(tokensAfterReload['preview-tablet']).toBe(tokensBeforeReload['preview-tablet'])
+      expect(tokensAfterReload['preview-mobile']).not.toBe(tokensBeforeReload['preview-mobile'])
+      const clientIdsAfterReload = await waitForHmrClientCount(3)
+      expect(new Set(clientIdsAfterReload).size).toBe(3)
+      expect(
+        clientIdsAfterReload.filter(clientId => clientIdsBeforeReload.includes(clientId))
+      ).toHaveLength(2)
+
+      await page.evaluate(() => {
+        const vrowzer = (window as any).__vrowzer__
+        const sessions = (window as any).__vrowzerMultiSessions
+        sessions.staleTablet = sessions.tablet
+        vrowzer.unmount('tablet')
+      })
+
+      expect(
+        await page.evaluate(() => ({
+          iframeCount: document.querySelectorAll('#preview-tablet iframe').length,
+          sessionIds: (window as any).__vrowzer__
+            .sessions()
+            .map((session: { id: string }) => session.id)
+        }))
+      ).toEqual({ iframeCount: 0, sessionIds: ['preview', 'mobile'] })
+      expect(await waitForHmrClientCount(2)).toHaveLength(2)
+
+      await page.evaluate(source => {
+        ;(window as any).__vrowzer__.updateFile('/main.js', source)
+      }, createMultiSessionSource('multi-3'))
+
+      await page.waitForFunction(
+        () =>
+          ['preview-container', 'preview-mobile'].every(containerId =>
+            document
+              .querySelector(`#${containerId} iframe`)
+              ?.contentDocument?.querySelector('[data-revision="multi-3"]')
+          ),
+        undefined,
+        { timeout: 30_000 }
+      )
+
+      await page.evaluate(() => {
+        const vrowzer = (window as any).__vrowzer__
+        const sessions = (window as any).__vrowzerMultiSessions
+        sessions.tablet = vrowzer.mount(document.getElementById('preview-tablet'), {
+          id: 'tablet',
+          params: { viewport: 'tablet-recreated' }
+        })
+      })
+
+      await page.waitForFunction(
+        () =>
+          document
+            .querySelector('#preview-tablet iframe')
+            ?.contentDocument?.querySelector('[data-revision="multi-3"]'),
+        undefined,
+        { timeout: 30_000 }
+      )
+
+      const staleResult = await page.evaluate(() => {
+        const vrowzer = (window as any).__vrowzer__
+        const sessions = (window as any).__vrowzerMultiSessions
+        sessions.staleTablet.reload()
+        sessions.staleTablet.unmount()
+        vrowzer.reloadPreview(sessions.staleTablet)
+        vrowzer.unmount(sessions.staleTablet)
+        return {
+          currentPreserved: vrowzer.getSession('tablet') === sessions.tablet,
+          iframeCount: document.querySelectorAll('#preview-tablet iframe').length
+        }
+      })
+
+      expect(staleResult).toEqual({ currentPreserved: true, iframeCount: 1 })
+      expect(await waitForHmrClientCount(3)).toHaveLength(3)
+
+      await page.evaluate(() => {
+        const vrowzer = (window as any).__vrowzer__
+        vrowzer.unmount('tablet')
+        vrowzer.unmount((window as any).__vrowzerMultiSessions.mobile)
+        document.getElementById('preview-tablet')?.remove()
+        document.getElementById('preview-mobile')?.remove()
+        document.getElementById('preview-duplicate')?.remove()
+        delete (window as any).__vrowzerMultiSessions
+      })
+
+      expect(
+        await page.evaluate(() =>
+          (window as any).__vrowzer__.sessions().map((session: { id: string }) => session.id)
+        )
+      ).toEqual(['preview'])
+      expect(await waitForHmrClientCount(1)).toHaveLength(1)
+    }, 120_000)
   })
 
   describe('Service Worker', () => {
@@ -909,5 +1277,44 @@ globalThis.__vrowzerFsHtmlProxyResults = results
       expect(response.body).toContain(expectedUrl)
       expect(response.body).not.toContain("url('/__preview__/server-origin-icon.png')")
     })
+  })
+
+  describe('all-session teardown', () => {
+    test('unmounts every iframe and remounts with the existing runtime', async () => {
+      const stateAfterUnmount = await page.evaluate(() => {
+        const vrowzer = (window as any).__vrowzer__
+        vrowzer.unmount()
+        return {
+          iframeCount: document.querySelectorAll('#preview-container iframe').length,
+          sessionCount: vrowzer.sessions().length
+        }
+      })
+
+      expect(stateAfterUnmount).toEqual({ iframeCount: 0, sessionCount: 0 })
+
+      await page.evaluate(() => {
+        const vrowzer = (window as any).__vrowzer__
+        vrowzer.mount(document.getElementById('preview-container'), {
+          id: 'remounted',
+          params: { viewport: 'remounted' }
+        })
+      })
+
+      await page.waitForFunction(
+        () =>
+          document
+            .querySelector('#preview-container iframe')
+            ?.contentDocument?.querySelector('[data-revision="multi-3"]'),
+        undefined,
+        { timeout: 30_000 }
+      )
+
+      expect(
+        await page.evaluate(() =>
+          (window as any).__vrowzer__.sessions().map((session: { id: string }) => session.id)
+        )
+      ).toEqual(['remounted'])
+      expect(await waitForHmrClientCount(1)).toHaveLength(1)
+    }, 60_000)
   })
 })

--- a/packages/vrowzer/src/index-ready-timeout.test.ts
+++ b/packages/vrowzer/src/index-ready-timeout.test.ts
@@ -94,4 +94,17 @@ describe('Vrowzer Service Worker ready timeout', () => {
     await expect(vrowzer.ready({ files: {} })).resolves.toBe(false)
     expect(consoleError).toHaveBeenCalledWith('[Vrowzer] ready() failed:', failure)
   })
+
+  test('rejects concurrent and subsequent ready calls', async () => {
+    const vrowzer = Vrowzer()
+
+    const firstReady = vrowzer.ready({ files: {} })
+    await expect(vrowzer.ready({ files: {} })).rejects.toThrow(
+      'ready() can only be called once per instance (current state: initializing)'
+    )
+    await expect(firstReady).resolves.toBe(true)
+    await expect(vrowzer.ready({ files: {} })).rejects.toThrow(
+      'ready() can only be called once per instance (current state: ready)'
+    )
+  })
 })

--- a/packages/vrowzer/src/index.test.ts
+++ b/packages/vrowzer/src/index.test.ts
@@ -1,5 +1,70 @@
-import { describe, expect, test } from 'vite-plus/test'
+import { afterEach, describe, expect, test, vi } from 'vite-plus/test'
 import { Vrowzer } from './index.ts'
+
+class TestContainer {
+  readonly children: TestIframe[] = []
+
+  appendChild(iframe: TestIframe): TestIframe {
+    iframe.parent = this
+    this.children.push(iframe)
+    return iframe
+  }
+}
+
+class TestIframe {
+  readonly attributes = new Map<string, string>()
+  readonly srcdocWrites: string[] = []
+  readonly style = { cssText: '' }
+  parent: TestContainer | null = null
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value)
+  }
+
+  set srcdoc(value: string) {
+    this.srcdocWrites.push(value)
+  }
+
+  get srcdoc(): string {
+    return this.srcdocWrites.at(-1) ?? ''
+  }
+
+  remove(): void {
+    if (!this.parent) {
+      return
+    }
+    const index = this.parent.children.indexOf(this)
+    if (index >= 0) {
+      this.parent.children.splice(index, 1)
+    }
+    this.parent = null
+  }
+}
+
+function setupDocument(): void {
+  vi.stubGlobal('document', {
+    createElement(tag: string) {
+      expect(tag).toBe('iframe')
+      return new TestIframe()
+    }
+  })
+}
+
+function createContainer(): HTMLElement {
+  return new TestContainer() as unknown as HTMLElement
+}
+
+function getTestContainer(container: HTMLElement): TestContainer {
+  return container as unknown as TestContainer
+}
+
+function getTestIframe(iframe: HTMLIFrameElement): TestIframe {
+  return iframe as unknown as TestIframe
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('Vrowzer factory', () => {
   test('returns frozen object', () => {
@@ -11,7 +76,10 @@ describe('Vrowzer factory', () => {
     const vrowzer = Vrowzer()
     expect(vrowzer.ready).toBeTypeOf('function')
     expect(vrowzer.mount).toBeTypeOf('function')
+    expect(vrowzer.getSession).toBeTypeOf('function')
+    expect(vrowzer.sessions).toBeTypeOf('function')
     expect(vrowzer.reloadPreview).toBeTypeOf('function')
+    expect(vrowzer.unmount).toBeTypeOf('function')
     expect(vrowzer.addFile).toBeTypeOf('function')
     expect(vrowzer.updateFile).toBeTypeOf('function')
     expect(vrowzer.deleteFile).toBeTypeOf('function')
@@ -24,6 +92,151 @@ describe('Vrowzer factory', () => {
     expect(vrowzer.once).toBeTypeOf('function')
     expect(vrowzer.emit).toBeTypeOf('function')
     expect(vrowzer.dispose).toBeTypeOf('function')
+  })
+})
+
+describe('Vrowzer preview sessions', () => {
+  test('mounts and returns a frozen preview session', () => {
+    setupDocument()
+    const container = createContainer()
+    const vrowzer = Vrowzer()
+
+    const session = vrowzer.mount(container, { id: 'desktop' })
+
+    expect(Object.isFrozen(session)).toBe(true)
+    expect(session.id).toBe('desktop')
+    expect(session.container).toBe(container)
+    expect(getTestContainer(container).children).toEqual([session.iframe])
+    expect(vrowzer.getSession('desktop')).toBe(session)
+    expect(vrowzer.sessions()).toEqual([session])
+  })
+
+  test('requires a non-empty session id', () => {
+    setupDocument()
+    const vrowzer = Vrowzer()
+
+    expect(() => vrowzer.mount(createContainer(), { id: '' })).toThrow(
+      'mount() requires a non-empty preview session id'
+    )
+  })
+
+  test('returns an existing session without moving or reloading it', () => {
+    setupDocument()
+    const firstContainer = createContainer()
+    const secondContainer = createContainer()
+    const vrowzer = Vrowzer()
+    const first = vrowzer.mount(firstContainer, {
+      id: 'mobile',
+      params: { width: '390' }
+    })
+    const iframe = getTestIframe(first.iframe)
+
+    const second = vrowzer.mount(secondContainer, {
+      id: 'mobile',
+      params: { width: '430' }
+    })
+
+    expect(second).toBe(first)
+    expect(iframe.srcdocWrites).toHaveLength(1)
+    expect(getTestContainer(firstContainer).children).toEqual([first.iframe])
+    expect(getTestContainer(secondContainer).children).toHaveLength(0)
+  })
+
+  test('returns a frozen snapshot of mounted sessions', () => {
+    setupDocument()
+    const vrowzer = Vrowzer()
+    const desktop = vrowzer.mount(createContainer(), { id: 'desktop' })
+    const mobile = vrowzer.mount(createContainer(), { id: 'mobile' })
+
+    const snapshot = vrowzer.sessions()
+
+    expect(Object.isFrozen(snapshot)).toBe(true)
+    expect(snapshot).toEqual([desktop, mobile])
+    expect(vrowzer.sessions()).not.toBe(snapshot)
+  })
+
+  test('reloads one session by object or id and all sessions without a target', () => {
+    setupDocument()
+    const vrowzer = Vrowzer()
+    const desktop = vrowzer.mount(createContainer(), { id: 'desktop' })
+    const mobile = vrowzer.mount(createContainer(), { id: 'mobile' })
+    const desktopIframe = getTestIframe(desktop.iframe)
+    const mobileIframe = getTestIframe(mobile.iframe)
+
+    vrowzer.reloadPreview(desktop)
+    expect(desktopIframe.srcdocWrites).toHaveLength(2)
+    expect(mobileIframe.srcdocWrites).toHaveLength(1)
+
+    vrowzer.reloadPreview('mobile')
+    expect(desktopIframe.srcdocWrites).toHaveLength(2)
+    expect(mobileIframe.srcdocWrites).toHaveLength(2)
+
+    vrowzer.reloadPreview()
+    expect(desktopIframe.srcdocWrites).toHaveLength(3)
+    expect(mobileIframe.srcdocWrites).toHaveLength(3)
+  })
+
+  test('unmounts one session or all sessions', () => {
+    setupDocument()
+    const vrowzer = Vrowzer()
+    const desktopContainer = createContainer()
+    const mobileContainer = createContainer()
+    const desktop = vrowzer.mount(desktopContainer, { id: 'desktop' })
+    const mobile = vrowzer.mount(mobileContainer, { id: 'mobile' })
+
+    desktop.unmount()
+
+    expect(vrowzer.getSession('desktop')).toBeUndefined()
+    expect(getTestContainer(desktopContainer).children).toHaveLength(0)
+    expect(vrowzer.sessions()).toEqual([mobile])
+
+    vrowzer.unmount()
+
+    expect(vrowzer.sessions()).toHaveLength(0)
+    expect(getTestContainer(mobileContainer).children).toHaveLength(0)
+  })
+
+  test('ignores a stale session object after its id is reused', () => {
+    setupDocument()
+    const vrowzer = Vrowzer()
+    const oldSession = vrowzer.mount(createContainer(), { id: 'mobile' })
+    oldSession.unmount()
+    const currentSession = vrowzer.mount(createContainer(), { id: 'mobile' })
+    const currentIframe = getTestIframe(currentSession.iframe)
+
+    oldSession.reload()
+    oldSession.unmount()
+    vrowzer.reloadPreview(oldSession)
+    vrowzer.unmount(oldSession)
+
+    expect(vrowzer.getSession('mobile')).toBe(currentSession)
+    expect(currentIframe.srcdocWrites).toHaveLength(1)
+    expect(getTestContainer(currentSession.container).children).toEqual([currentSession.iframe])
+  })
+
+  test('snapshots and safely serializes preview context', () => {
+    setupDocument()
+    const params = {
+      marker: '</script>\u2028\u2029',
+      width: '390'
+    }
+    const options = {
+      id: 'mobile</script>\u2028\u2029',
+      params
+    }
+    const vrowzer = Vrowzer()
+    const session = vrowzer.mount(createContainer(), options)
+    options.id = 'changed'
+    params.width = '430'
+
+    session.reload()
+
+    const srcdoc = getTestIframe(session.iframe).srcdoc
+    expect(srcdoc).toContain('"id":"mobile\\u003c/script>\\u2028\\u2029"')
+    expect(srcdoc).toContain('"marker":"\\u003c/script>\\u2028\\u2029"')
+    expect(srcdoc).toContain('"width":"390"')
+    expect(srcdoc).not.toContain('"width":"430"')
+    expect(vrowzer.getSession('mobile</script>\u2028\u2029')).toBe(session)
   })
 })
 

--- a/packages/vrowzer/src/index.ts
+++ b/packages/vrowzer/src/index.ts
@@ -19,7 +19,7 @@
  *
  * if (ready) {
  *   // Mount preview iframe into a container element
- *   vrowzer.mount(document.getElementById('preview-container'))
+ *   vrowzer.mount(document.getElementById('preview-container'), { id: 'preview' })
  * }
  *
  * // Update files (triggers HMR)
@@ -63,6 +63,8 @@ import type { SvcWorkerControllerEventMap } from '@vrowzer/service-worker/contro
 
 const DEFAULT_SERVICE_WORKER_READY_TIMEOUT = 60_000
 const DEFAULT_WEB_WORKER_SETUP_TIMEOUT = 90_000
+
+type ReadyState = 'idle' | 'initializing' | 'ready' | 'failed'
 
 /**
  * VrowzerOptions defines the configuration options for {@link Vrowzer}.
@@ -123,6 +125,74 @@ export interface VrowzerConfig {
 }
 
 /**
+ * Options for mounting a preview session.
+ */
+export interface PreviewMountOptions {
+  /**
+   * Host-defined identity for the preview pane.
+   */
+  id: string
+  /**
+   * Values exposed to the preview document before its scripts run.
+   */
+  params?: Record<string, string>
+}
+
+/**
+ * Context exposed to the mounted preview document.
+ */
+export interface PreviewContext {
+  /**
+   * Host-defined preview session identity.
+   */
+  readonly id: string
+  /**
+   * Optional values provided when the preview session was mounted.
+   */
+  readonly params?: Readonly<Record<string, string>>
+}
+
+/**
+ * A mounted preview iframe managed by a {@link Vrowzer} instance.
+ */
+export interface PreviewSession {
+  /**
+   * Host-defined preview session identity.
+   */
+  readonly id: string
+  /**
+   * Iframe used by this preview session.
+   */
+  readonly iframe: HTMLIFrameElement
+  /**
+   * Container that owns the iframe.
+   */
+  readonly container: HTMLElement
+  /**
+   * Reloads only this preview document.
+   */
+  reload(): void
+  /**
+   * Removes only this preview document.
+   */
+  unmount(): void
+}
+
+/**
+ * A preview session target accepted by lifecycle methods.
+ */
+export type PreviewSessionRef = string | PreviewSession
+
+declare global {
+  interface Window {
+    /**
+     * Context for the current Vrowzer preview document.
+     */
+    __VROWZER_PREVIEW__?: Readonly<PreviewContext>
+  }
+}
+
+/**
  * Event map for {@link Vrowzer}.
  *
  * Forwards all {@link SvcWorkerControllerEventMap} events from the underlying Service Worker controller.
@@ -138,6 +208,7 @@ export interface Vrowzer extends Emittable<VrowzerEventMap> {
    *
    * This method initializes the Web Worker, Service Worker, and MessageChannel,
    * then syncs initial files to both workers.
+   * It can only be called once per Vrowzer instance.
    *
    * @return A promise that resolves to `true` if the boot process is successful, or `false` if it fails.
    */
@@ -148,13 +219,37 @@ export interface Vrowzer extends Emittable<VrowzerEventMap> {
    * Creates a credentialless iframe with srcdoc bootstrap that fetches
    * the preview HTML via the Service Worker.
    *
+   * Reusing an existing session ID returns the original session without reloading or moving it.
+   * The container and params from the first mount remain in effect.
+   *
    * @param container - A DOM element where the preview iframe will be mounted.
+   * @param options - Preview identity and context values.
+   * @returns The mounted preview session.
    */
-  mount(container: HTMLElement): void
+  mount(container: HTMLElement, options: PreviewMountOptions): PreviewSession
   /**
-   * Reloads the preview iframe
+   * Returns the currently mounted preview session for an ID.
+   *
+   * @param id - Host-defined preview session identity.
    */
-  reloadPreview(): void
+  getSession(id: string): PreviewSession | undefined
+  /**
+   * Returns a snapshot of all currently mounted preview sessions.
+   */
+  sessions(): readonly PreviewSession[]
+  /**
+   * Reloads one preview session, or every session when no target is provided.
+   *
+   * @param target - A session ID or mounted session object.
+   */
+  reloadPreview(target?: PreviewSessionRef): void
+  /**
+   * Unmounts one preview session, or every session when no target is provided.
+   * The shared Service Worker, Web Worker, and virtual filesystem remain active.
+   *
+   * @param target - A session ID or mounted session object.
+   */
+  unmount(target?: PreviewSessionRef): void
   /**
    * Adds a new file to the preview environment with the specified content.
    *
@@ -181,6 +276,11 @@ interface ResolvedVrowzerOptions {
   serviceWorkerScope: string
   serviceWorkerReadyTimeout: number
   webWorkerSetupTimeout: number
+}
+
+interface PreviewSessionRecord {
+  context: Readonly<PreviewContext>
+  session: PreviewSession
 }
 
 function resolveVrowzerOptions(options: VrowzerOptions): ResolvedVrowzerOptions {
@@ -210,6 +310,17 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
   })
 }
 
+function serializeInlineScriptValue(value: unknown): string {
+  const serialized = JSON.stringify(value)
+  if (serialized === undefined) {
+    throw new TypeError('Preview bootstrap value is not serializable')
+  }
+  return serialized
+    .replaceAll('<', '\\u003c')
+    .replaceAll('\u2028', '\\u2028')
+    .replaceAll('\u2029', '\\u2029')
+}
+
 /**
  * Factory function to create a {@link Vrowzer} instance.
  * @param options - Configuration options for the Vrowzer instance.
@@ -220,8 +331,9 @@ export function Vrowzer(options: VrowzerOptions = {}): Readonly<Vrowzer> {
 
   const _emitter = Emitter<VrowzerEventMap>()
   const publisher: FileSystemPublisher = createFileSystemPublisher()
+  const previewSessions = new Map<string, PreviewSessionRecord>()
   let webWorker: Worker | null = null
-  let iframe: HTMLIFrameElement | null = null
+  let readyState: ReadyState = 'idle'
 
   function cleanupWebWorker(): void {
     if (!webWorker) {
@@ -285,7 +397,10 @@ export function Vrowzer(options: VrowzerOptions = {}): Readonly<Vrowzer> {
     )
   }
 
-  function createBootstrapHtml(previewUrl: string): string {
+  function createBootstrapHtml(previewUrl: string, context: Readonly<PreviewContext>): string {
+    const serializedPreviewUrl = serializeInlineScriptValue(previewUrl)
+    const serializedContext = serializeInlineScriptValue(context)
+
     // Fetch preview HTML via SW, then inject DOM and execute scripts manually.
     // We avoid document.write() (deprecated) because it doesn't guarantee
     // ESM module execution order in about:srcdoc iframes.
@@ -294,7 +409,7 @@ export function Vrowzer(options: VrowzerOptions = {}): Readonly<Vrowzer> {
 <script>
 (async () => {
   try {
-    const res = await fetch('${previewUrl}');
+    const res = await fetch(${serializedPreviewUrl});
     const html = await res.text();
     const origin = new URL(res.url).origin;
     const parsed = new DOMParser().parseFromString(html, 'text/html');
@@ -305,6 +420,13 @@ export function Vrowzer(options: VrowzerOptions = {}): Readonly<Vrowzer> {
     document.body.innerHTML = '';
     for (const n of [...parsed.body.childNodes])
       if (n.nodeName !== 'SCRIPT') document.body.appendChild(document.importNode(n, true));
+
+    // Expose the pane context before any preview script runs.
+    const previewContext = ${serializedContext};
+    if (previewContext.params) Object.freeze(previewContext.params);
+    Object.freeze(previewContext);
+    document.documentElement.dataset.vrowzerPreviewId = previewContext.id;
+    window.__VROWZER_PREVIEW__ = previewContext;
 
     // Pre-setup React DevTools hook so hook.inject() populates renderers Map
     // before React Refresh's injectIntoGlobalHook() wraps it.
@@ -362,9 +484,39 @@ function execScript(orig, origin) {
 </body></html>`
   }
 
+  function resolveSession(target: PreviewSessionRef): PreviewSessionRecord | undefined {
+    if (typeof target === 'string') {
+      return previewSessions.get(target)
+    }
+    const record = previewSessions.get(target.id)
+    return record?.session === target ? record : undefined
+  }
+
+  function reloadSession(record: PreviewSessionRecord): void {
+    if (previewSessions.get(record.session.id) !== record) {
+      return
+    }
+    record.session.iframe.srcdoc = createBootstrapHtml(resolved.basePath, record.context)
+  }
+
+  function unmountSession(record: PreviewSessionRecord): void {
+    if (previewSessions.get(record.session.id) !== record) {
+      return
+    }
+    previewSessions.delete(record.session.id)
+    record.session.iframe.remove()
+  }
+
   const instance: Vrowzer = {
     ..._emitter,
     async ready(config: VrowzerConfig): Promise<boolean> {
+      if (readyState !== 'idle') {
+        throw new Error(
+          `[Vrowzer] ready() can only be called once per instance (current state: ${readyState})`
+        )
+      }
+      readyState = 'initializing'
+
       try {
         // 1. Create Web Worker + add as publisher target
         webWorker = new Worker(new URL('./web-worker.ts', import.meta.url), { type: 'module' })
@@ -497,16 +649,28 @@ function execScript(orig, origin) {
         // 8. Establish MessageChannel (Service Worker ↔ Web Worker)
         await establishChannel()
 
+        readyState = 'ready'
         return true
       } catch (error) {
+        readyState = 'failed'
         cleanupWebWorker()
         console.error('[Vrowzer] ready() failed:', error)
         return false
       }
     },
 
-    mount(container: HTMLElement): void {
-      iframe = document.createElement('iframe')
+    mount(container: HTMLElement, options: PreviewMountOptions): PreviewSession {
+      if (!options || typeof options.id !== 'string' || options.id.length === 0) {
+        throw new TypeError('[Vrowzer] mount() requires a non-empty preview session id')
+      }
+
+      const id = options.id
+      const existing = previewSessions.get(id)
+      if (existing) {
+        return existing.session
+      }
+
+      const iframe = document.createElement('iframe')
       iframe.setAttribute(
         'sandbox',
         'allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox'
@@ -515,13 +679,68 @@ function execScript(orig, origin) {
       iframe.style.cssText = 'width: 100%; height: 100%; border: none;'
       container.appendChild(iframe)
 
+      const params = options.params === undefined ? undefined : Object.freeze({ ...options.params })
+      const context: Readonly<PreviewContext> = Object.freeze({
+        id,
+        ...(params === undefined ? {} : { params })
+      })
+      let session!: PreviewSession
+      session = Object.freeze({
+        id,
+        iframe,
+        container,
+        reload: () => {
+          const record = previewSessions.get(id)
+          if (record?.session === session) {
+            reloadSession(record)
+          }
+        },
+        unmount: () => {
+          const record = previewSessions.get(id)
+          if (record?.session === session) {
+            unmountSession(record)
+          }
+        }
+      })
+      const record = { context, session }
+      previewSessions.set(id, record)
+
       // srcdoc bootstrap: fetch preview HTML via Service Worker
-      iframe.srcdoc = createBootstrapHtml(resolved.basePath)
+      iframe.srcdoc = createBootstrapHtml(resolved.basePath, context)
+      return session
     },
 
-    reloadPreview(): void {
-      if (iframe) {
-        iframe.srcdoc = createBootstrapHtml(resolved.basePath)
+    getSession(id: string): PreviewSession | undefined {
+      return previewSessions.get(id)?.session
+    },
+
+    sessions(): readonly PreviewSession[] {
+      return Object.freeze([...previewSessions.values()].map(record => record.session))
+    },
+
+    reloadPreview(target?: PreviewSessionRef): void {
+      if (target === undefined) {
+        for (const record of [...previewSessions.values()]) {
+          reloadSession(record)
+        }
+        return
+      }
+      const record = resolveSession(target)
+      if (record) {
+        reloadSession(record)
+      }
+    },
+
+    unmount(target?: PreviewSessionRef): void {
+      if (target === undefined) {
+        for (const record of [...previewSessions.values()]) {
+          unmountSession(record)
+        }
+        return
+      }
+      const record = resolveSession(target)
+      if (record) {
+        unmountSession(record)
       }
     },
 


### PR DESCRIPTION
Adds first-class preview sessions so one Vrowzer runtime can manage multiple iframe panes. Mounting now requires a stable ID and returns an immutable session with targeted reload and unmount operations. Preview context is injected before application scripts execute.

The HMR MessageChannel lifecycle now disconnects documents on page teardown and removes closed clients from the worker server, including connections closed during handshake. Unit, integration, E2E, docs, and existing mount call sites are updated.

Closes #30.